### PR TITLE
add disqus comments as per hpstr theme

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,6 +2,7 @@ title:            Site Title
 description:      Describe your website.
 # Your site's domain goes here. Leave localhost server or blank when working locally.
 url:              http://localhost:4000
+disqus_shortname: 
 
 # Owner/author information
 owner:

--- a/_includes/_disqus_comments.html
+++ b/_includes/_disqus_comments.html
@@ -1,0 +1,21 @@
+<script type="text/javascript">
+    /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */
+    var disqus_shortname = '{{ site.disqus_shortname }}'; // required: replace example with your forum shortname
+
+    /* * * DON'T EDIT BELOW THIS LINE * * */
+    (function() {
+        var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
+        dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
+        (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
+    })();
+
+    /* * * DON'T EDIT BELOW THIS LINE * * */
+    (function () {
+        var s = document.createElement('script'); s.async = true;
+        s.type = 'text/javascript';
+        s.src = '//' + disqus_shortname + '.disqus.com/count.js';
+        (document.getElementsByTagName('HEAD')[0] || document.getElementsByTagName('BODY')[0]).appendChild(s);
+    }());
+</script>
+<noscript>Please enable JavaScript to view the <a href="http://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
+<a href="http://disqus.com" class="dsq-brlink">comments powered by <span class="logo-disqus">Disqus</span></a>

--- a/_includes/_scripts.html
+++ b/_includes/_scripts.html
@@ -18,3 +18,6 @@
   })();
 </script>
 {% endif %}
+{% if page.comments %}
+  {% include _disqus_comments.html %}
+{% endif %}

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -39,6 +39,9 @@
     <div class="article-wrap">
       {{ content }}
     </div><!-- /.article-wrap -->
+    {% if site.disqus_shortname and page.comments %}
+      <section id="disqus_thread"></section><!-- /#disqus_thread -->
+    {% endif %}
   </article>
 </div><!-- /#index -->
 

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -48,6 +48,9 @@
         <p class="byline"><strong>{{ page.title }}</strong> was published on <time datetime="{{ page.date | date_to_xmlschema }}">{{ page.date | date: "%B %d, %Y" }}</time>{% if page.modified %} and last modified on <time datetime="{{ page.modified | date: "%Y-%m-%d" }}">{{ page.modified | date: "%B %d, %Y" }}</time>{% endif %} by <a href="{{ site.url }}/about" title="About {{ site.owner.name }}">{{ site.owner.name }}</a>.</p>
       </footer>
     </div><!-- /.article-wrap -->
+  {% if site.disqus_shortname and page.comments %}
+    <section id="disqus_thread"></section><!-- /#disqus_thread -->
+  {% endif %}
   </article>
 </div><!-- /#main -->
 

--- a/_posts/2011-03-10-sample-post.md
+++ b/_posts/2011-03-10-sample-post.md
@@ -4,6 +4,7 @@ title: Sample Post
 description: "Just about everything you'll need to style in the theme: headings, paragraphs, blockquotes, tables, code blocks, and more."
 modified: 2013-05-31
 tags: [intro, beginner, jekyll, tutorial]
+comments: true
 image:
   feature: texture-feature-05.jpg
   credit: Texture Lovers

--- a/_posts/2012-05-22-readability-post.md
+++ b/_posts/2012-05-22-readability-post.md
@@ -3,6 +3,7 @@ layout: post
 title: "Testing Readability with a Bunch of Text"
 description: "A ton of text to test readability."
 tags: [sample post, readability, test]
+comments: true
 ---
 
 Portland in shoreditch Vice, labore typewriter pariatur hoodie fap sartorial Austin. Pinterest literally occupy Schlitz forage. Odio ad blue bottle vinyl, 90's narwhal commodo bitters pour-over nostrud. Ugh est hashtag in, fingerstache adipisicing laboris esse Pinterest shabby chic Portland. Shoreditch bicycle rights anim, flexitarian laboris put a bird on it vinyl cupidatat narwhal. Hashtag artisan skateboard, flannel Bushwick nesciunt salvia aute fixie do plaid post-ironic dolor McSweeney's. Cliche pour-over chambray nulla four loko skateboard sapiente hashtag.

--- a/_posts/2013-05-22-sample-post-images.md
+++ b/_posts/2013-05-22-sample-post-images.md
@@ -3,6 +3,7 @@ layout: post
 title: "A Post with Images"
 description: "Examples and code for displaying images in posts."
 tags: [sample post, images, test]
+comments: true
 ---
 
 Here are some examples of what a post with images might look like. If you want to display two or three images next to each other responsively use `figure` with the appropriate `class`. Each instance of `figure` is auto-numbered and displayed in the caption.

--- a/_posts/2013-05-23-readability-feature-post.md
+++ b/_posts/2013-05-23-readability-feature-post.md
@@ -3,6 +3,7 @@ layout: post
 title: "Post with Large Feature Image and Text"
 description: "Custom written post descriptions are the way to go... if you're not lazy."
 tags: [sample post, readability, test]
+comments: true
 image:
   feature: texture-feature-04.jpg
   credit: Texture Lovers

--- a/_posts/2013-08-16-code-highlighting-post.md
+++ b/_posts/2013-08-16-code-highlighting-post.md
@@ -3,6 +3,7 @@ layout: post
 title: Syntax Highlighting Post
 description: "Demo post displaying the various ways of highlighting code in Markdown."
 tags: [sample post, code, highlighting]
+comments: true
 ---
 
 [Syntax highlighting](http://en.wikipedia.org/wiki/Syntax_highlighting) is a feature that displays source code, in different colors and fonts according to the category of terms. This feature facilitates writing in a structured language such as a programming language or a markup language as both structures and syntax errors are visually distinct. Highlighting does not affect the meaning of the text itself; it is intended only for human readers.

--- a/about.md
+++ b/about.md
@@ -5,6 +5,7 @@ title: About the Theme
 tagline: Minimal Mistakes, a Jekyll Theme
 tags: [about, Jekyll, theme, responsive]
 modified: 9-9-2013
+comments: true
 image:
   feature: texture-feature-02.jpg
   credit: Texture Lovers


### PR DESCRIPTION
subject line says it all.

Hope this is ok.

I added `comment: true` to  `about.md`so people could see that pages can have disqus, too, in principle (even though that makes little sense for an about.

Ps.: this is the cleaned version of #37.
