### PR TITLE
add info about notices in sample post

### DIFF
--- a/_posts/2011-03-10-sample-post.md
+++ b/_posts/2011-03-10-sample-post.md
@@ -95,3 +95,9 @@ HTML and CSS are our tools. Mauris a ante. Suspendisse quam sem, consequat at, c
 Make any link standout more when applying the `.btn` class.
 
 <div markdown="0"><a href="#" class="btn">This is a button</a></div>
+
+
+## Notices
+
+**Watch out!** You can also add notices by appending `{: .notice}` to a paragraph.
+{: .notice}


### PR DESCRIPTION
I noticed (by accident) that minimal mistakes also features notices, so I thought it'd be nice to highlight this in a sample post.
