### PR TITLE
minor fix to link color settings

### DIFF
--- a/assets/less/typography.less
+++ b/assets/less/typography.less
@@ -28,14 +28,14 @@ a {
 	text-decoration: none;
 	color: @link-color; 
 	&:visited { 
-		color: lighten(@link-color, 20); 
+		color: @linkcolorvisited; 
 	}
 	&:hover { 
-		color: darken(@link-color, 20); 
+		color: @linkcolorhover; 
 	}
 	&:focus { 
 		outline: thin dotted; 
-		color: darken(@link-color, 20);
+		color: @linkcolorfocus;
 	}
 	&:hover, 
 	&:active { 


### PR DESCRIPTION
Fix allows users to change @linkcolorhover, @linkcolorfocus and @linkcolorvisited from the variables.less file. In the original source code, the link color settings in typography.less did not match link colors settings in variables.less. This caused the link settings in the typography file to override the link settings in variables.less file.
