### PR TITLE
forkme-on-github ribbons added, user can be configure ribbon on _config....

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -51,5 +51,17 @@ owner:
   steam: #username
   dribbble: #username
 
+# Fprk me on Githıb ribbon for any position on page
+forkme:
+  # If you type `true` in active attribute, the ribbon will be appared on page
+  active: true
+  # Type the title field what you want to see on ribbon
+  title: Fork me on Github
+  # enter your fork url on `url` attribute
+  url: https://github.com/muhasturk/muhasturk.github.io/fork
+  # Position value must be one of following
+  # [ top-left, top-right, bottom-left, bottom-right ]
+  position: top-right
+
 include: [".htaccess"]
 exclude: ["lib", "config.rb", "Capfile", "config", "log", "Rakefile", "Rakefile.rb", "tmp", "less", "*.sublime-project", "*.sublime-workspace", "test", "spec", "Gruntfile.js", "package.json", "node_modules", "Gemfile", "Gemfile.lock", "LICENSE", "README.md"]

--- a/_includes/_forkme.html
+++ b/_includes/_forkme.html
@@ -1,0 +1,23 @@
+{% if site.forkme.active == true %}
+{% assign yml_position = site.forkme.position %}
+{% case yml_position %}
+{% when 'top-right' %}
+{% assign position = 'right' %}
+{% when 'top-left' %}
+{% assign position = 'left' %}
+{% when 'bottom-right' %} 
+{% assign position = 'right-bottom' %}        
+{% when 'bottom-left' %} 
+{% assign position = 'left-bottom' %}
+{% else %}
+<mark style="color: #990000">unsupported forkme position attribute in _config.yml</mark>
+{% endcase %}
+{% if position  %}
+<div class="github-fork-ribbon-wrapper {{ position }}">
+    <div class="github-fork-ribbon">
+        <a href="{{ site.forkme.url }}">{{ site.forkme.title }}</a>
+    </div>
+</div>
+{% endif %}
+{% endif %}
+

--- a/_includes/_head.html
+++ b/_includes/_head.html
@@ -51,3 +51,10 @@
 <link rel="apple-touch-icon-precomposed" sizes="114x114" href="{{ site.url }}/images/apple-touch-icon-114x114-precomposed.png">
 <!-- 144x144 (precomposed) for iPad 3rd and 4th generation -->
 <link rel="apple-touch-icon-precomposed" sizes="144x144" href="{{ site.url }}/images/apple-touch-icon-144x144-precomposed.png">
+
+{% if site.forkme.active == true %}<!-- forkme-on-github ribbon -->
+<link rel="stylesheet" href="{{ site.url }}/assets/css/gh-fork-ribbon.css">
+<!--[if lt IE 9]>
+<link rel="stylesheet" href="{{ site.url }}/assets/css/gh-fork-ribbon.ie.css">
+<![endif]-->
+{% endif %}

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -13,6 +13,8 @@
 
 {% include _navigation.html %}
 
+{% include _forkme.html %}
+
 {% if page.image.feature %}
   <div class="image-wrap">
   <img src=

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -13,6 +13,8 @@
 
 {% include _navigation.html %}
 
+{% include _forkme.html %}
+
 {% if page.image.feature %}
   <div class="image-wrap">
   <img src=

--- a/_layouts/post-index.html
+++ b/_layouts/post-index.html
@@ -13,6 +13,8 @@
 
 {% include _navigation.html %}
 
+{% include _forkme.html %}
+
 {% if page.image.feature %}
   <div class="image-wrap">
   <img src=

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -13,6 +13,8 @@
 
 {% include _navigation.html %}
 
+{% include _forkme.html %}
+
 {% if page.image.feature %}
   <div class="image-wrap">
   <img src=

--- a/assets/css/gh-fork-ribbon.css
+++ b/assets/css/gh-fork-ribbon.css
@@ -1,0 +1,140 @@
+/*!
+ * "Fork me on GitHub" CSS ribbon v0.1.1 | MIT License
+ * https://github.com/simonwhitaker/github-fork-ribbon-css
+*/
+
+/* Left will inherit from right (so we don't need to duplicate code) */
+.github-fork-ribbon {
+  /* The right and left classes determine the side we attach our banner to */
+  position: absolute;
+
+  /* Add a bit of padding to give some substance outside the "stitching" */
+  padding: 2px 0;
+
+  /* Set the base colour */
+  background-color: #a00;
+
+  /* Set a gradient: transparent black at the top to almost-transparent black at the bottom */
+  background-image: -webkit-gradient(linear, left top, left bottom, from(rgba(0, 0, 0, 0)), to(rgba(0, 0, 0, 0.15)));
+  background-image: -webkit-linear-gradient(top, rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.15));
+  background-image: -moz-linear-gradient(top, rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.15));
+  background-image: -ms-linear-gradient(top, rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.15));
+  background-image: -o-linear-gradient(top, rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.15));
+  background-image: linear-gradient(to bottom, rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.15));
+
+  /* Add a drop shadow */
+  -webkit-box-shadow: 0 2px 3px 0 rgba(0, 0, 0, 0.5);
+  -moz-box-shadow: 0 2px 3px 0 rgba(0, 0, 0, 0.5);
+  box-shadow: 0 2px 3px 0 rgba(0, 0, 0, 0.5);
+
+  /* Set the font */
+  font: 700 13px "Helvetica Neue", Helvetica, Arial, sans-serif;
+
+  z-index: 9999;
+  pointer-events: auto;
+}
+
+.github-fork-ribbon a,
+.github-fork-ribbon a:hover {
+  /* Set the text properties */
+  color: #fff;
+  text-decoration: none;
+  text-shadow: 0 -1px rgba(0, 0, 0, 0.5);
+  text-align: center;
+
+  /* Set the geometry. If you fiddle with these you'll also need
+     to tweak the top and right values in .github-fork-ribbon. */
+  width: 200px;
+  line-height: 20px;
+
+  /* Set the layout properties */
+  display: inline-block;
+  padding: 2px 0;
+
+  /* Add "stitching" effect */
+  border-width: 1px 0;
+  border-style: dotted;
+  border-color: #fff;
+  border-color: rgba(255, 255, 255, 0.7);
+}
+
+.github-fork-ribbon-wrapper {
+  width: 150px;
+  height: 150px;
+  position: absolute;
+  overflow: hidden;
+  top: 0;
+  z-index: 9999;
+  pointer-events: none;
+}
+
+.github-fork-ribbon-wrapper.fixed {
+  position: fixed;
+}
+
+.github-fork-ribbon-wrapper.left {
+  left: 0;
+}
+
+.github-fork-ribbon-wrapper.right {
+  right: 0;
+}
+
+.github-fork-ribbon-wrapper.left-bottom {
+  position: fixed;
+  top: inherit;
+  bottom: 0;
+  left: 0;
+}
+
+.github-fork-ribbon-wrapper.right-bottom {
+  position: fixed;
+  top: inherit;
+  bottom: 0;
+  right: 0;
+}
+
+.github-fork-ribbon-wrapper.right .github-fork-ribbon {
+  top: 42px;
+  right: -43px;
+
+  -webkit-transform: rotate(45deg);
+  -moz-transform: rotate(45deg);
+  -ms-transform: rotate(45deg);
+  -o-transform: rotate(45deg);
+  transform: rotate(45deg);
+}
+
+.github-fork-ribbon-wrapper.left .github-fork-ribbon {
+  top: 42px;
+  left: -43px;
+
+  -webkit-transform: rotate(-45deg);
+  -moz-transform: rotate(-45deg);
+  -ms-transform: rotate(-45deg);
+  -o-transform: rotate(-45deg);
+  transform: rotate(-45deg);
+}
+
+
+.github-fork-ribbon-wrapper.left-bottom .github-fork-ribbon {
+  top: 80px;
+  left: -43px;
+
+  -webkit-transform: rotate(45deg);
+  -moz-transform: rotate(45deg);
+  -ms-transform: rotate(45deg);
+  -o-transform: rotate(45deg);
+  transform: rotate(45deg);
+}
+
+.github-fork-ribbon-wrapper.right-bottom .github-fork-ribbon {
+  top: 80px;
+  right: -43px;
+
+  -webkit-transform: rotate(-45deg);
+  -moz-transform: rotate(-45deg);
+  -ms-transform: rotate(-45deg);
+  -o-transform: rotate(-45deg);
+  transform: rotate(-45deg);
+}

--- a/assets/css/gh-fork-ribbon.ie.css
+++ b/assets/css/gh-fork-ribbon.ie.css
@@ -1,0 +1,78 @@
+/*!
+ * "Fork me on GitHub" CSS ribbon v0.1.1 | MIT License
+ * https://github.com/simonwhitaker/github-fork-ribbon-css
+*/
+
+/* IE voodoo courtesy of http://stackoverflow.com/a/4617511/263871 and
+ * http://www.useragentman.com/IETransformsTranslator */
+
+ .github-fork-ribbon {
+  filter: progid:DXImageTransform.Microsoft.gradient(GradientType=0,StartColorStr='#000000', EndColorStr='#000000');
+}
+
+.github-fork-ribbon-wrapper.right .github-fork-ribbon {
+  /* IE positioning hack (couldn't find a transform-origin alternative for IE) */
+  top: -22px;
+  right: -62px;
+
+  /* IE8+ */
+  -ms-filter: "progid:DXImageTransform.Microsoft.Matrix(M11=0.7071067811865474, M12=-0.7071067811865477, M21=0.7071067811865477, M22=0.7071067811865474, SizingMethod='auto expand')";
+  /* IE6 and 7 */
+  filter: progid:DXImageTransform.Microsoft.Matrix(
+    M11=0.7071067811865474,
+    M12=-0.7071067811865477,
+    M21=0.7071067811865477,
+    M22=0.7071067811865474,
+    SizingMethod='auto expand'
+  );
+}
+
+.github-fork-ribbon-wrapper.left .github-fork-ribbon {
+  top: -22px;
+  left: -22px;
+
+  /* IE8+ */
+  -ms-filter: "progid:DXImageTransform.Microsoft.Matrix(M11=0.7071067811865483, M12=0.7071067811865467, M21=-0.7071067811865467, M22=0.7071067811865483, SizingMethod='auto expand')";
+  /* IE6 and 7 */
+  filter: progid:DXImageTransform.Microsoft.Matrix(
+    M11=0.7071067811865483,
+    M12=0.7071067811865467,
+    M21=-0.7071067811865467,
+    M22=0.7071067811865483,
+    SizingMethod='auto expand'
+  );
+}
+
+.github-fork-ribbon-wrapper.left-bottom .github-fork-ribbon {
+  /* IE positioning hack (couldn't find a transform-origin alternative for IE) */
+  top: 12px;
+  left: -22px;
+
+
+  /* IE8+ */
+  -ms-filter: "progid:DXImageTransform.Microsoft.Matrix(M11=0.7071067811865474, M12=-0.7071067811865477, M21=0.7071067811865477, M22=0.7071067811865474, SizingMethod='auto expand')";
+  /* IE6 and 7 */
+/*  filter: progid:DXImageTransform.Microsoft.Matrix(
+    M11=0.7071067811865474,
+    M12=-0.7071067811865477,
+    M21=0.7071067811865477,
+    M22=0.7071067811865474,
+    SizingMethod='auto expand'
+  );
+*/}
+
+.github-fork-ribbon-wrapper.right-bottom .github-fork-ribbon {
+  top: 12px;
+  right: -62px;
+
+  /* IE8+ */
+  -ms-filter: "progid:DXImageTransform.Microsoft.Matrix(M11=0.7071067811865483, M12=0.7071067811865467, M21=-0.7071067811865467, M22=0.7071067811865483, SizingMethod='auto expand')";
+  /* IE6 and 7 */
+  filter: progid:DXImageTransform.Microsoft.Matrix(
+    M11=0.7071067811865483,
+    M12=0.7071067811865467,
+    M21=-0.7071067811865467,
+    M22=0.7071067811865483,
+    SizingMethod='auto expand'
+  );
+}


### PR DESCRIPTION
Hello,
I integrated [Fork me on Github ribbon](https://github.com/simonwhitaker/github-fork-ribbon-css) project in this theme. User can be enable ribbon on **_config.yml** with simple `active:true` command.

There are also three options to set position of ribbon, title of ribbon and of course fork url of ribbon.

--------------
## Explanation
__title__ can be anything,
__position__ should be following things
* top-left
* top-right
* bottom-left
* bottom-right

__url__ does not have to be github url.

### Section on _*config.yml*
![](http://storage9.static.itmages.com/i/14/0913/h_1410572808_8259772_b6acde9fa3.png "on _config.yml")

### finaly theme looks like
**default theme**  
![](http://storage8.static.itmages.com/i/14/0913/h_1410573147_9494873_81544eedab.png "fork me on-github ribbon on default theme")
**example page**  
![](http://storage6.static.itmages.com/i/14/0913/h_1410572981_7848413_60f2b03a86.png "fork me-on-github ribbon on mustafahasturk.com")


Finally thanks for this awesome theme and the others.

