### PR TITLE
facebook sharing image meta tag added related #149 issue

### DIFF
--- a/_includes/_open-graph.html
+++ b/_includes/_open-graph.html
@@ -17,3 +17,8 @@
 {% if page.excerpt %}<meta property="og:description" content="{{ page.excerpt | strip_html }}">{% endif %}
 <meta property="og:url" content="{{ page.url | replace:'index.html','' | prepend: site.url }}">
 <meta property="og:site_name" content="{{ site.title }}">
+{% if page.image.feature %}
+<meta property="og:image" content="{{ site.url }}/images/{{ page.image.feature }}">
+{% else %}
+<meta property="og:image" content="{% if page.image.thumb %}{{ site.url }}/images/{{ page.image.thumb }}{% else %}{{ site.url }}/images/default-thumb.png{% endif %}">
+{% endif %}


### PR DESCRIPTION
facebook meta tag image sharing added in the_open-graph.html realted to #149 issue. While sharing posts or page using facebook shar its not picking the rite image. Now its corrected adding ioen graph image tag added.