### PR TITLE
Add CodePen to owner social options

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -55,6 +55,7 @@ owner:
   soundcloud: #username
   weibo: #username
   flickr: #username
+  codepen: #username
 
 include: [".htaccess"]
 exclude: ["lib", "config.rb", "Capfile", "config", "log", "Rakefile", "Rakefile.rb", "tmp", "less", "*.sublime-project", "*.sublime-workspace", "test", "spec", "Gruntfile.js", "package.json", "node_modules", "Gemfile", "Gemfile.lock", "LICENSE", "README.md"]

--- a/_includes/_author-bio.html
+++ b/_includes/_author-bio.html
@@ -31,4 +31,5 @@
   {% if author.soundcloud %}<a href="http://soundcloud.com/{{ author.soundcloud }}" class="author-social" target="_blank"><i class="fa fa-fw fa-soundcloud"></i> Soundcloud</a>{% endif %}
   {% if author.weibo %}<a href="http://www.weibo.com/{{ author.weibo }}" class="author-social" target="_blank"><i class="fa fa-fw fa-weibo"></i> Weibo</a>{% endif %}
   {% if author.flickr %}<a href="http://www.flickr.com/{{ author.flickr }}" class="author-social" target="_blank"><i class="fa fa-fw fa-flickr"></i> Flickr</a>{% endif %}
+  {% if author.codepen %}<a href="http://codepen.io/{{ author.codepen }}" class="author-social" target="_blank"><i class="fa fa-fw fa-codepen"></i> CodePen</a>{% endif %}
 </div>


### PR DESCRIPTION
I wanted to include CodePen on my site, and since there's already a [FontAwesome icon for it](http://fortawesome.github.io/Font-Awesome/icon/codepen/), seemed like an easy addition that I thought others could benefit from.