### PR TITLE
fix #170

### DIFF
--- a/_includes/_head.html
+++ b/_includes/_head.html
@@ -35,7 +35,7 @@
 <!-- Modernizr -->
 <script src="{{ site.url }}/assets/js/vendor/modernizr-2.7.1.custom.min.js"></script>
 
-<link href='//fonts.googleapis.com/css?family=PT+Sans+Narrow:400,700%7CPT+Serif:400,700,400italic' rel='stylesheet' type='text/css'>
+<link href="http://fonts.googleapis.com/css?family=PT+Serif:400,400italic,700|PT+Sans:400,700,400italic|PT+Sans+Narrow:400,700&subset=latin-ext,latin" rel='stylesheet' type='text/css'>
 
 <!-- Icons -->
 <!-- 16x16 -->


### PR DESCRIPTION
Google font link now includes latin-extended characters for PT family fonts.