### PR TITLE
Remove navigation role as it is unnecessary

### DIFF
--- a/_includes/_navigation.html
+++ b/_includes/_navigation.html
@@ -3,7 +3,7 @@
 		<a href="{{ site.url }}/">{{ site.title }}</a>
 	</div><!-- /.site-name -->
 	<div class="top-navigation">
-		<nav role="navigation" id="site-nav" class="nav">
+		<nav id="site-nav" class="nav">
 		    <ul>
 		        {% for link in site.data.navigation %}
 				    {% if link.url contains 'http' %}


### PR DESCRIPTION
Remove unnecessary role element.

See:

http://stackoverflow.com/questions/31831214/bootstrap-html-validator-warning-element-nav-does-not-need-a-role-attribute

https://validator.w3.org/nu/?doc=https%3A%2F%2Fmmistakes.github.io%2Fminimal-mistakes%2F