### PR TITLE
Removed duplicate 'powered by Disqus'

### DIFF
--- a/_includes/_disqus_comments.html
+++ b/_includes/_disqus_comments.html
@@ -19,5 +19,4 @@
     }());
 </script>
 <noscript>Please enable JavaScript to view the <a href="http://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
-<a href="http://disqus.com" class="dsq-brlink">comments powered by <span class="logo-disqus">Disqus</span></a>
 {% endif %}


### PR DESCRIPTION
This also fixes an issue during page load with Disqus comments on them, `comments powered by Disqus` displayed then got pushed down.