### PR TITLE
Use uglifyjs npm script

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
     "type": "git",
     "url": "git://github.com/mmistakes/minimal-mistakes.git"
   },
+  "scripts": {
+    "build": "uglifyjs assets/js/plugins/*.js assets/js/_*.js -o assets/js/scripts.min.js"
+  },
   "bugs": {
     "url": "https://github.com/mmistakes/minimal-mistakes/issues"
   },
@@ -15,11 +18,12 @@
   "devDependencies": {
     "grunt": "~0.4.1",
     "grunt-contrib-clean": "~0.5.0",
+    "grunt-contrib-imagemin": "~0.2.0",
     "grunt-contrib-jshint": "~0.6.3",
     "grunt-contrib-uglify": "~0.2.2",
     "grunt-contrib-watch": "~0.5.2",
     "grunt-recess": "~0.3.5",
-    "grunt-contrib-imagemin": "~0.2.0",
-    "grunt-svgmin": "~0.2.0"
+    "grunt-svgmin": "~0.2.0",
+    "uglify-js": "^2.6.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,11 +18,11 @@
   "devDependencies": {
     "grunt": "~0.4.1",
     "grunt-contrib-clean": "~0.5.0",
-    "grunt-contrib-imagemin": "~0.2.0",
     "grunt-contrib-jshint": "~0.6.3",
     "grunt-contrib-uglify": "~0.2.2",
     "grunt-contrib-watch": "~0.5.2",
     "grunt-recess": "~0.3.5",
+    "grunt-contrib-imagemin": "~0.2.0",
     "grunt-svgmin": "~0.2.0",
     "uglify-js": "^2.6.1"
   }


### PR DESCRIPTION
You can run this via `npm run build`. If you like it, you can remove the grunt-related dependencies from package.json. You can use the standalone jshint library if you want to keep linting as part of the project. You can do the same thing for image/svg compression.

You can create separate npm scripts in package.json and then run them with one command like this:
```json
{
  "lint": "jshint ./",
  "compress": "compressor ./img...",
  "uglify": "uglifyjs ...... -o ...",
  "build": "npm run lint && npm run compress & npm run uglify"
}
```