### PR TITLE
Fix "build:all" npm script

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,6 @@
     "watch:all": "npm-run-all --parallel watch:css watch:js",
     "build:css": "npm run scss && npm run autoprefixer",
     "build:js": "npm run uglify",
-    "build:all": "npm run build:css && build:js"
+    "build:all": "npm run build:css && npm run build:js"
   }
 }


### PR DESCRIPTION
The script "build:all" was missing the "npm run" section for the "build:js" part.