### PR TITLE
Add Speaker Deck author profile link

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -81,6 +81,7 @@ author:
   linkedin         :
   pinterest        :
   soundcloud       :
+  speakerdeck      :
   stackoverflow    : # http://stackoverflow.com/users/123456/username
   steam            :
   tumblr           :

--- a/_includes/author-profile.html
+++ b/_includes/author-profile.html
@@ -64,6 +64,9 @@
       {% if author.stackoverflow %}
         <li><a href="https://www.stackoverflow.com/users/{{ author.stackoverflow }}"><i class="fa fa-fw fa-stack-overflow" aria-hidden="true"></i> Stackoverflow</a></li>
       {% endif %}
+      {% if author.speakerdeck %}
+        <li><a href="https://speakerdeck.com/{{ author.speakerdeck }}"><i class="fa fa-fw fa-speaker-deck" aria-hidden="true"></i> Speaker Deck</a></li>
+      {% endif %}
       {% if author.lastfm %}
         <li><a href="https://lastfm.com/user/{{ author.lastfm }}"><i class="fa fa-fw fa-lastfm-square" aria-hidden="true"></i> Last.fm</a></li>
       {% endif %}

--- a/assets/_scss/_utilities.scss
+++ b/assets/_scss/_utilities.scss
@@ -258,6 +258,10 @@ body:hover .visually-hidden button {
     color: $stackoverflow-color;
   }
 
+  .fa-speaker-deck {
+    #color: $speakerdeck-color;
+  }
+
   .fa-tumblr,
   .fa-tumblr-square {
     color: $tumblr-color;

--- a/assets/_scss/_variables.scss
+++ b/assets/_scss/_variables.scss
@@ -81,6 +81,7 @@ $pinterest-color            : #cb2027;
 $rss-color                  : #fa9b39;
 $soundcloud-color           : #ff3300;
 $stackoverflow-color        : #fe7a15;
+$speakerdeck-color          : #396;
 $tumblr-color               : #32506d;
 $twitter-color              : #55acee;
 $vimeo-color                : #1ab7ea;

--- a/assets/_scss/vendor/font-awesome/_icons.scss
+++ b/assets/_scss/vendor/font-awesome/_icons.scss
@@ -378,6 +378,7 @@
 .#{$fa-css-prefix}-youtube-play:before { content: $fa-var-youtube-play; }
 .#{$fa-css-prefix}-dropbox:before { content: $fa-var-dropbox; }
 .#{$fa-css-prefix}-stack-overflow:before { content: $fa-var-stack-overflow; }
+.#{$fa-css-prefix}-speaker-deck:before { content: $fa-var-external-link; }
 .#{$fa-css-prefix}-instagram:before { content: $fa-var-instagram; }
 .#{$fa-css-prefix}-flickr:before { content: $fa-var-flickr; }
 .#{$fa-css-prefix}-adn:before { content: $fa-var-adn; }


### PR DESCRIPTION
This commit adds the Speaker Deck link to the author profile.  As there is no logo for Speaker Deck in the Font, a simple external link icon is used.