### PR TITLE
Removed duplicate class styling

### DIFF
--- a/assets/_scss/_utilities.scss
+++ b/assets/_scss/_utilities.scss
@@ -263,11 +263,6 @@ body:hover .visually-hidden button {
     color: $tumblr-color;
   }
 
-  .fa-twitter,
-  .fa-twitter-square {
-    color: $twitter-color;
-  }
-
   .fa-vimeo,
   .fa-vimeo-square {
     color: $vimeo-color;


### PR DESCRIPTION
The `fa-twitter` class was styled twice. Removed the duplicate one.