### PR TITLE
Translate index page title

### DIFF
--- a/_data/ui-text.yml
+++ b/_data/ui-text.yml
@@ -26,6 +26,7 @@ en: &DEFAULT_EN
   powered_by            : "Powered by"
   website_label         : "Website"
   email_label           : "Email"
+  recent_posts          : "Recent Posts"
 en-US:
   <<: *DEFAULT_EN
 en-UK:

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@ author_profile: true
 
 {% include base_path %}
 
-<h3 class="archive__subtitle">Recent Posts</h3>
+<h3 class="archive__subtitle">{{ site.data.ui-text[site.locale].recent_posts }}</h3>
 
 {% for post in paginator.posts %}
   {% include archive-single.html %}


### PR DESCRIPTION
I recently succeed to install and build my site with this theme (I got some issues with osx…). I have noticed that the page title of the index page was not translated.
Let me know if I can make other pull request like this or if it's preferable to "hard translate" in template inside of my project/repository.
Thanks

PS : I also have noticed a "no new line at end of file" diff but I don't know how to fix that. I am with osx and used vim to edit. I hope it's not a problem for you.