### PR TITLE
javascript to embed comments from discourse forum

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -18,9 +18,11 @@ teaser                   : # filename of teaser fallback teaser image placed in 
 # breadcrumbs            : false # true, false (default)
 words_per_minute         : 200
 comments:
-  provider               : # false (default), "disqus", "facebook", "google-plus", custom"
+  provider               : # false (default), "disqus", "discourse", "facebook", "google-plus", custom"
   disqus:
     shortname            : # https://help.disqus.com/customer/portal/articles/466208-what-s-a-shortname-
+  discourse:
+    server               : # https://meta.discourse.org/t/embedding-discourse-comments-via-javascript/31963 , e.g.: meta.discourse.org
   facebook:
     # https://developers.facebook.com/docs/plugins/comments
     appid                :

--- a/_includes/comments-providers/discourse.html
+++ b/_includes/comments-providers/discourse.html
@@ -1,0 +1,13 @@
+{% if site.comments.discourse.server %}
+{% capture canonical %}{{ site.url }}{% if site.permalink contains '.html' %}{{ page.url }}{% else %}{{ page.url | remove:'index.html' | strip_slash }}{% endif %}{% endcapture %}
+<script type="text/javascript">
+    DiscourseEmbed = { discourseUrl: '//{{ site.comments.discourse.server }}/',
+                       discourseEmbedUrl: '{{ canonical }}' };
+   (function () {
+     var d = document.createElement('script'); d.type = 'text/javascript'; d.async = true;
+     d.src = DiscourseEmbed.discourseUrl + 'javascripts/embed.js';
+     (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(d);
+   })();
+</script>
+<noscript>Please enable JavaScript to view the comments powered by [Discourse](http://forum.beta-europe.org/c/beta/website).</a></noscript>
+{% endif %}

--- a/_includes/comments-providers/discourse.html
+++ b/_includes/comments-providers/discourse.html
@@ -1,5 +1,6 @@
 {% if site.comments.discourse.server %}
-{% capture canonical %}{{ site.url }}{% if site.permalink contains '.html' %}{{ page.url }}{% else %}{{ page.url | remove:'index.html' | strip_slash }}{% endif %}{% endcapture %}
+{% include base_path %}
+{% capture canonical %}{{ base_path }}{% if site.permalink contains '.html' %}{{ page.url }}{% else %}{{ page.url | remove:'index.html' | strip_slash }}{% endif %}{% endcapture %}
 <script type="text/javascript">
     DiscourseEmbed = { discourseUrl: '//{{ site.comments.discourse.server }}/',
                        discourseEmbedUrl: '{{ canonical }}' };

--- a/_includes/comments-providers/scripts.html
+++ b/_includes/comments-providers/scripts.html
@@ -3,6 +3,8 @@
 {% case site.comments.provider %}
 {% when "disqus" %}
   {% include /comments-providers/disqus.html %}
+{% when "discourse" %}
+  {% include /comments-providers/discourse.html %}
 {% when "facebook" %}
   {% include /comments-providers/facebook.html %}
 {% when "google-plus" %}


### PR DESCRIPTION
The comment system can be changed to embed topics from the Discourse
forum software: http://discourse.org/

More details: https://meta.discourse.org/t/embedding-discourse-comments-via-javascript/31963