### PR TITLE
Open Graph Image Tag for Header Overlay Images

### DIFF
--- a/_includes/seo.html
+++ b/_includes/seo.html
@@ -85,6 +85,8 @@
 
 {% if page.header.image %}
   <meta property="og:image" content="{% if page.header.image contains "://" %}{{ page.header.image }}{% else %}{{ page.header.image | prepend: "/images/" | prepend: base_path }}{% endif %}">
+{% elsif page.header.overlay_image %}
+  <meta property="og:image" content="{% if page.header.overlay_image contains "://" %}{{ page.header.overlay_image }}{% else %}{{ page.header.overlay_image | prepend: "/images/" | prepend: base_path }}{% endif %}">
 {% endif %}
 
 {% if page.date %}
@@ -113,7 +115,7 @@
   <script type="application/ld+json">
     {
       "@context" : "http://schema.org",
-      "@type" : "{% if site.social.type %}{{ site.social.type }}{% else %}person{% endif %}",
+      "@type" : "{% if site.social.type %}{{ site.social.type }}{% else %}Person{% endif %}",
       "name" : "{{ site.social.name | default: site.name }}",
       "url" : {{ seo_url | jsonify }},
       "sameAs" : {{ site.social.links | jsonify }}


### PR DESCRIPTION
Add Open Graph Image tag if `page.header.overlay_image` is used. Additionally, fix a casing issue in the theme's generated microdata.