### PR TITLE
Updated author-profile.html in the event that there is no authors.yml file

### DIFF
--- a/_includes/author-profile.html
+++ b/_includes/author-profile.html
@@ -1,6 +1,6 @@
 {% include base_path %}
 
-{% if page.author %}
+{% if page.author and site.data.authors[page.author] %}
   {% assign author = site.data.authors[page.author] %}{% else %}{% assign author = site.author %}
 {% endif %}
 


### PR DESCRIPTION
I do not have an authors.yml file and so using this when a post has an author was failing.  Added check to see if there is an author in the data and if not, defaults to author data from _config.yml.