### PR TITLE
clarified comment for author.stackoverflow value in _config.yml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -97,7 +97,7 @@ author:
   linkedin         :
   pinterest        :
   soundcloud       :
-  stackoverflow    : # http://stackoverflow.com/users/123456/username
+  stackoverflow    : # "123456/username" (the last part of your profile url, e.g. http://stackoverflow.com/users/123456/username)
   steam            :
   tumblr           :
   twitter          :


### PR DESCRIPTION
# Initial Situation

* The author.stackoverflow variable was commentet with `# http://stackoverflow.com/users/123456/username`, which led me to the conclusion that I should add the whole url as value.
* The stackoverflow combination of numeric id / username isn't self-explanatory.

# Proposed Change

Change the comment to explicit state the requested value `"123456/username"` and append the whole demo url to show where the needed value can be found.