### PR TITLE
get Follow-Button label from ui-text and default to "Follow"

### DIFF
--- a/_includes/author-profile.html
+++ b/_includes/author-profile.html
@@ -20,7 +20,7 @@
   </div>
 
   <div class="author__urls-wrapper">
-    <button class="btn btn--inverse">Follow</button>
+    <button class="btn btn--inverse">{{ site.data.ui-text[site.locale].follow_label | remove: ":" | default: "Follow" }}</button>
     <ul class="author__urls social-icons">
       {% if author.location %}
         <li><i class="fa fa-fw fa-map-marker" aria-hidden="true"></i> {{ author.location }}</li>


### PR DESCRIPTION
The Follow button Label wasn't localized with the ui-text value, now it is with default to "Follow".

The colon from the end of the ui-text value of `follow_label` is being removed by the liquid filter `remove: ":"`