### PR TITLE
Remove duplicate include of base_path in category-list.html

### DIFF
--- a/_includes/category-list.html
+++ b/_includes/category-list.html
@@ -1,7 +1,5 @@
 {% include base_path %}
 
-{% include base_path %}
-
 {% case site.category_archive.type %}
   {% when "liquid" %}
     {% assign path_type = "#" %}


### PR DESCRIPTION
I noticed that base_path is included twice in category-list.html.
Does not seem to have any reason why it is included twice. 
The second overwrites the first.