### PR TITLE
Add classnames to body element

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -10,7 +10,7 @@
     {% include head/custom.html %}
   </head>
 
-  <body class="layout--{{ page.layout | default: layout.layout }}">
+  <body class="layout--{{ page.layout | default: layout.layout }}{% if page.classes or layout.classes %}{{ page.classes | default: layout.classes | join: ' ' | prepend: ' ' }}{% endif %}">
 
     {% include browser-upgrade.html %}
     {% include masthead.html %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -10,7 +10,7 @@
     {% include head/custom.html %}
   </head>
 
-  <body>
+  <body class="layout--{{ page.layout | default: layout.layout }}">
 
     {% include browser-upgrade.html %}
     {% include masthead.html %}


### PR DESCRIPTION
Feature enhancement that adds the 2 related capabilities that enable users to:

1. Detect the layout of a page via CSS or JavaScript, and
2. Toggle various user-defined classes in the `body` tag's `class` attribute by assigning an array of classnames to the `page.classes` or `layout.classes` variables. If `page.classes` is defined, overrides `layout.classes`. (I would prefer concatenation, but that doesn't seem to work).

This enables users to specify custom styles to use for specific pages and components on that page. 
For instances, the landing page might have specific styling that is only used on that page.

```yaml
---
layout: splash
classes:
  - landing
  - dark-theme
---
```

Outputs:

```html
<body class="layout--splash landing dark-theme">
```
