### PR TITLE
add Chinese and German (Deutsch) to the languages list

### DIFF
--- a/_docs/07-ui-text.md
+++ b/_docs/07-ui-text.md
@@ -12,7 +12,9 @@ Text for various UI elements, `_layouts`, and `_includes` have all been grouped 
 Currently the English[^yaml-anchors] main keys in `_data/ui-text.yml` are translated to the following languages:
 
 * Brazilian Portguese (Português brasileiro)
+* Chinese
 * French (Français)
+* German (Deutsch)
 * Italian (Italiano)
 * Spanish (Español)
 * Turkish (Türkçe)


### PR DESCRIPTION
Hi Michael, here's the Docs addition PR for the follwing two PR's:

* #546 (add german (Deutsch) translation)
* #532 (Add zh-CN)

Thank you and have fun
Roger