### PR TITLE
add image helper for easier image insertion in posts

### DIFF
--- a/_includes/image
+++ b/_includes/image
@@ -3,7 +3,7 @@
     {% if include.image_path contains "://" %}
       "{{ include.image_path }}"
     {% else %}
-      "{{ include.image_path | prepend: "/assets/images/" | absolute_url }}"
+      "{{ include.image_path | absolute_url }}"
     {% endif %}
     alt="{% if include.alt %}{{ include.alt }}{% endif %}">
   {% if include.caption %}

--- a/_includes/image
+++ b/_includes/image
@@ -1,11 +1,9 @@
-{% include base_path %}
-
 <figure class="{{ include.class }}">
   <img src=
     {% if include.image_path contains "://" %}
       "{{ include.image_path }}"
     {% else %}
-      "{{ include.image_path | prepend: "/assets/images/" | prepend: base_path }}"
+      "{{ include.image_path | prepend: "/assets/images/" | prepend: absolute_url }}"
     {% endif %}
     alt="{% if include.alt %}{{ include.alt }}{% endif %}">
   {% if include.caption %}

--- a/_includes/image
+++ b/_includes/image
@@ -1,0 +1,14 @@
+{% include base_path %}
+
+<figure class="{{ include.class }}">
+  <img src=
+    {% if include.image_path contains "://" %}
+      "{{ include.image_path }}"
+    {% else %}
+      "{{ include.image_path | prepend: "/assets/images/" | prepend: base_path }}"
+    {% endif %}
+    alt="{% if include.alt %}{{ include.alt }}{% endif %}">
+  {% if include.caption %}
+    <figcaption>{{ include.caption | markdownify | remove: "<p>" | remove: "</p>" }}</figcaption>
+  {% endif %}
+</figure>

--- a/_includes/image
+++ b/_includes/image
@@ -3,7 +3,7 @@
     {% if include.image_path contains "://" %}
       "{{ include.image_path }}"
     {% else %}
-      "{{ include.image_path | prepend: "/assets/images/" | prepend: absolute_url }}"
+      "{{ include.image_path | prepend: "/assets/images/" | absolute_url }}"
     {% endif %}
     alt="{% if include.alt %}{{ include.alt }}{% endif %}">
   {% if include.caption %}


### PR DESCRIPTION
This PR adds an 'image' helper for easier insertion of image in posts (#560)

It handles both local images (it assumes images are under `assets/images`) and urls.

in order to add an image to a post, just use the following syntax:

`{% include image image_path="2016/07/MyPostImage.png" caption="The optional image caption" %}`

or

`{% include image image_path="https://example.com/images/MyPostImage.png" caption="The optional image caption" alt="The optional alt text" %}`

Parameters are:
- `image_path` (mandatory): the image path. It can be an url or a local path. In the former case, it assumes images are under `assets/images`, so you only need to specify the path from there.
- `caption` (optional): the image caption.
- `alt` (optional): the alt text.

What you think?
