### PR TITLE
Repair aggressive box-shadow in navigation.

### DIFF
--- a/_sass/_navigation.scss
+++ b/_sass/_navigation.scss
@@ -258,7 +258,7 @@
     border: 1px solid $border-color;
     border-radius: $border-radius;
     background: #fff;
-    box-shadow: 0 8px 16px 1px rgba(#000, 0.2);
+    box-shadow: 0 2px 4px 0 rgba(#000, 0.16), 0 2px 10px 0 rgba(#000, 0.12);
 
     a {
       margin: 0;

--- a/_sass/_navigation.scss
+++ b/_sass/_navigation.scss
@@ -258,7 +258,7 @@
     border: 1px solid $border-color;
     border-radius: $border-radius;
     background: #fff;
-    box-shadow: 0 0 10px rgba(#000, 0.25);
+    box-shadow: 0 8px 16px 4px rgba(#000, 0.2);
 
     a {
       margin: 0;

--- a/_sass/_navigation.scss
+++ b/_sass/_navigation.scss
@@ -258,7 +258,7 @@
     border: 1px solid $border-color;
     border-radius: $border-radius;
     background: #fff;
-    box-shadow: 0 8px 16px 4px rgba(#000, 0.2);
+    box-shadow: 0 8px 16px 1px rgba(#000, 0.2);
 
     a {
       margin: 0;


### PR DESCRIPTION
Before:

<img width="303" alt="screenshot 2016-10-08 22 47 14" src="https://cloud.githubusercontent.com/assets/1976088/19215841/3b9f65be-8da9-11e6-9e01-a4e35ad9ecba.png">

After:

<img width="299" alt="screenshot 2016-10-08 22 47 03" src="https://cloud.githubusercontent.com/assets/1976088/19215842/3bb8740a-8da9-11e6-820a-51750b85d150.png">
