### PR TITLE
disqus: Use canonical URL and whitespace clean-up

### DIFF
--- a/_includes/comments-providers/disqus.html
+++ b/_includes/comments-providers/disqus.html
@@ -1,27 +1,25 @@
 {% if site.comments.disqus.shortname %}
 {% capture canonical %}{{ base_path }}{% if site.permalink contains '.html' %}{{ page.url }}{% else %}{{ page.url | remove:'index.html' | strip_slash }}{% endif %}{% endcapture %}
   <script type="text/javascript">
-  	/* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */
-  	var disqus_shortname = '{{ site.comments.disqus.shortname }}';
+    var disqus_shortname = '{{ site.comments.disqus.shortname }}';
 
-  	var disqus_config = function () {
-  		 this.page.url = '{{ canonical }}';
-  	};
+    var disqus_config = function () {
+      this.page.url = '{{ canonical }}';
+    };
 
-  	/* * * DON'T EDIT BELOW THIS LINE * * */
-  	(function() {
-  		var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-  		dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
-  		(document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
-  	})();
+    (function() {
+      var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
+      dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
+      (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
+    })();
 
-  	/* * * DON'T EDIT BELOW THIS LINE * * */
-  	(function () {
-  		var s = document.createElement('script'); s.async = true;
-  		s.type = 'text/javascript';
-  		s.src = '//' + disqus_shortname + '.disqus.com/count.js';
-  		(document.getElementsByTagName('HEAD')[0] || document.getElementsByTagName('BODY')[0]).appendChild(s);
-  	}());
+    (function () {
+      var s = document.createElement('script'); s.async = true;
+      s.type = 'text/javascript';
+      s.src = '//' + disqus_shortname + '.disqus.com/count.js';
+      (document.getElementsByTagName('HEAD')[0] || document.getElementsByTagName('BODY')[0]).appendChild(s);
+    }());
+
   </script>
   <noscript>Please enable JavaScript to view the <a href="http://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
 {% endif %}

--- a/_includes/comments-providers/disqus.html
+++ b/_includes/comments-providers/disqus.html
@@ -1,7 +1,12 @@
 {% if site.comments.disqus.shortname %}
+{% capture canonical %}{{ base_path }}{% if site.permalink contains '.html' %}{{ page.url }}{% else %}{{ page.url | remove:'index.html' | strip_slash }}{% endif %}{% endcapture %}
   <script type="text/javascript">
   	/* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */
   	var disqus_shortname = '{{ site.comments.disqus.shortname }}';
+
+  	var disqus_config = function () {
+  		 this.page.url = '{{ canonical }}';
+  	};
 
   	/* * * DON'T EDIT BELOW THIS LINE * * */
   	(function() {


### PR DESCRIPTION
Fix an issue that would cause Disqus to server different comments for every possible variation of URL (defaulted to `window.location.href`) including things such as GET parameters, Google translate, localhost development servers and more.

Clean-up white space while we're at it.

See individual commits for more detail.
