### PR TITLE
Fix #264: broken link in configuration doc

### DIFF
--- a/_docs/05-configuration.md
+++ b/_docs/05-configuration.md
@@ -566,7 +566,7 @@ tag_archive:
 
 Which would create category and tag links in the breadcrumbs and page meta like: `/categories/#foo` and `/tags/#foo`.
 
-**Note:** for these links to resolve properly, category and tag index pages need to exist at [`/categories/index.html`](https://github.com/{{ site.repository }}/gh-pages/_pages/category-archive.html) and [`/tags/index.html`](https://github.com/{{ site.repository }}/gh-pages/_pages/tag-archive.html). The necessary Liquid code to build these pages can be taken from the demo site.
+**Note:** for these links to resolve properly, category and tag index pages need to exist at [`/categories/index.html`](https://github.com/{{ site.repository }}/blob/gh-pages/_pages/category-archive.html) and [`/tags/index.html`](https://github.com/{{ site.repository }}/blob/gh-pages/_pages/tag-archive.html). The necessary Liquid code to build these pages can be taken from the demo site.
 {: .notice--warning}
 
 If you have the luxury of using Jekyll Plugins then [**jekyll-archives**][jekyll-archives] will make your life much easier as category and tag pages are created for you.


### PR DESCRIPTION
This reverts the changes in issue #264.
The links in https://mmistakes.github.io/minimal-mistakes/docs/configuration/ under Archive Settings lead to 404/page not found. 
Adding /blob/ again fixes it.

![image](https://cloud.githubusercontent.com/assets/5385290/19513197/64969412-95ef-11e6-8a34-f926afcbc72d.png)
