### PR TITLE
Add structured data markup for `itemtype="http://schema.org/Person"` in author-profile.html

### DIFF
--- a/_includes/author-profile.html
+++ b/_includes/author-profile.html
@@ -1,5 +1,7 @@
 {% if page.author and site.data.authors[page.author] %}
-  {% assign author = site.data.authors[page.author] %}{% else %}{% assign author = site.author %}
+  {% assign author = site.data.authors[page.author] %}
+{% else %}
+  {% assign author = site.author %}
 {% endif %}
 
 <div itemscope itemtype="http://schema.org/Person">
@@ -7,95 +9,182 @@
   {% if author.avatar %}
     <div class="author__avatar">
       {% if author.avatar contains "://" %}
-      	<img src="{{ author.avatar }}" alt="{{ author.name }}">
+        <img src="{{ author.avatar }}" alt="{{ author.name }}" itemprop="image">
       {% else %}
-      	<img src="{{ author.avatar | absolute_url }}" class="author__avatar" alt="{{ author.name }}">
+        <img src="{{ author.avatar | absolute_url }}" class="author__avatar" alt="{{ author.name }}" itemprop="image">
       {% endif %}
     </div>
   {% endif %}
 
   <div class="author__content">
-    <h3 class="author__name">{{ author.name }}</h3>
-    {% if author.bio %}<p class="author__bio">{{ author.bio }}</p>{% endif %}
+    <h3 class="author__name" itemprop="name">{{ author.name }}</h3>
+    {% if author.bio %}
+      <p class="author__bio" itemprop="description">
+        {{ author.bio }}
+      </p>
+    {% endif %}
   </div>
 
   <div class="author__urls-wrapper">
     <button class="btn btn--inverse">{{ site.data.ui-text[site.locale].follow_label | remove: ":" | default: "Follow" }}</button>
     <ul class="author__urls social-icons">
       {% if author.location %}
-        <li><i class="fa fa-fw fa-map-marker" aria-hidden="true"></i> {{ author.location }}</li>
+        <li itemprop="homeLocation" itemscope itemtype="http://schema.org/Place">
+          <i class="fa fa-fw fa-map-marker" aria-hidden="true"></i> 
+          <span itemprop="name"> {{ author.location }} </span>
+        </li>
       {% endif %}
+      
       {% if author.uri %}
-        <li><a href="{{ author.uri }}"><i class="fa fa-fw fa-chain" aria-hidden="true"></i> {{ site.data.ui-text[site.locale].website_label | default: "Website" }}</a></li>
+        <li>
+          <a href="{{ author.uri }}" itemprop="url">
+            <i class="fa fa-fw fa-chain" aria-hidden="true"></i> 
+              {{ site.data.ui-text[site.locale].website_label | default: "Website" }}
+          </a>
+        </li>
       {% endif %}
+      
       {% if author.email %}
-        <li><a href="mailto:{{ author.email }}"><i class="fa fa-fw fa-envelope-square" aria-hidden="true"></i> {{ site.data.ui-text[site.locale].email_label | default: "Email" }}</a></li>
+        <li>
+          <a href="mailto:{{ author.email }}">
+            <i class="fa fa-fw fa-envelope-square" aria-hidden="true"></i>
+            <meta itemprop="email" content="{{ author.email }}" />
+            {{ site.data.ui-text[site.locale].email_label | default: "Email" }}
+          </a>
+        </li>
       {% endif %}
+      
       {% if author.keybase %}
-        <li><a href="https://keybase.io/{{ author.keybase }}"><i class="fa fa-fw fa-key" aria-hidden="true"></i> Keybase</a></li>
+        <li><a href="https://keybase.io/{{ author.keybase }} " itemprop="sameAs">
+          <i class="fa fa-fw fa-key" aria-hidden="true"></i> 
+          Keybase
+        </a></li>
       {% endif %}
       {% if author.twitter %}
-        <li><a href="https://twitter.com/{{ author.twitter }}"><i class="fa fa-fw fa-twitter-square" aria-hidden="true"></i> Twitter</a></li>
+        <li><a href="https://twitter.com/{{ author.twitter }}" itemprop="sameAs">
+          <i class="fa fa-fw fa-twitter-square" aria-hidden="true"></i> 
+          Twitter
+        </a></li>
       {% endif %}
       {% if author.facebook %}
-        <li><a href="https://www.facebook.com/{{ author.facebook }}"><i class="fa fa-fw fa-facebook-square" aria-hidden="true"></i> Facebook</a></li>
+        <li><a href="https://www.facebook.com/{{ author.facebook }}" itemprop="sameAs">
+          <i class="fa fa-fw fa-facebook-square" aria-hidden="true"></i> 
+          Facebook
+        </a></li>
       {% endif %}
       {% if author.google_plus %}
-        <li><a href="https://plus.google.com/+{{ author.google_plus }}"><i class="fa fa-fw fa-google-plus-square" aria-hidden="true"></i> Google+</a></li>
+        <li><a href="https://plus.google.com/+{{ author.google_plus }}" itemprop="sameAs">
+          <i class="fa fa-fw fa-google-plus-square" aria-hidden="true"></i> 
+          Google+
+        </a></li>
       {% endif %}
       {% if author.linkedin %}
-        <li><a href="https://www.linkedin.com/in/{{ author.linkedin }}"><i class="fa fa-fw fa-linkedin-square" aria-hidden="true"></i> LinkedIn</a></li>
+        <li><a href="https://www.linkedin.com/in/{{ author.linkedin }}" itemprop="sameAs">
+          <i class="fa fa-fw fa-linkedin-square" aria-hidden="true"></i> 
+          LinkedIn
+        </a></li>
       {% endif %}
       {% if author.xing %}
-        <li><a href="https://www.xing.com/profile/{{ author.xing }}"><i class="fa fa-fw fa-xing-square" aria-hidden="true"></i> XING</a></li>
+        <li><a href="https://www.xing.com/profile/{{ author.xing }}" itemprop="sameAs">
+          <i class="fa fa-fw fa-xing-square" aria-hidden="true"></i> 
+          XING
+        </a></li>
       {% endif %}
       {% if author.instagram %}
-        <li><a href="https://instagram.com/{{ author.instagram }}"><i class="fa fa-fw fa-instagram" aria-hidden="true"></i> Instagram</a></li>
+        <li><a href="https://instagram.com/{{ author.instagram }}" itemprop="sameAs">
+          <i class="fa fa-fw fa-instagram" aria-hidden="true"></i> 
+          Instagram
+        </a></li>
       {% endif %}
       {% if author.tumblr %}
-        <li><a href="https://{{ author.tumblr }}.tumblr.com"><i class="fa fa-fw fa-tumblr-square" aria-hidden="true"></i> Tumblr</a></li>
+        <li><a href="https://{{ author.tumblr }}.tumblr.com" itemprop="sameAs">
+          <i class="fa fa-fw fa-tumblr-square" aria-hidden="true"></i> 
+          Tumblr
+        </a></li>
       {% endif %}
       {% if author.bitbucket %}
-        <li><a href="https://bitbucket.org/{{ author.bitbucket }}"><i class="fa fa-fw fa-bitbucket" aria-hidden="true"></i> Bitbucket</a></li>
+        <li><a href="https://bitbucket.org/{{ author.bitbucket }}" itemprop="sameAs">
+          <i class="fa fa-fw fa-bitbucket" aria-hidden="true"></i> 
+          Bitbucket
+        </a></li>
       {% endif %}
       {% if author.github %}
-        <li><a href="https://github.com/{{ author.github }}"><i class="fa fa-fw fa-github" aria-hidden="true"></i> Github</a></li>
+        <li><a href="https://github.com/{{ author.github }}" itemprop="sameAs">
+          <i class="fa fa-fw fa-github" aria-hidden="true"></i> 
+          Github
+        </a></li>
       {% endif %}
       {% if author.stackoverflow %}
-        <li><a href="https://www.stackoverflow.com/users/{{ author.stackoverflow }}"><i class="fa fa-fw fa-stack-overflow" aria-hidden="true"></i> Stackoverflow</a></li>
+        <li><a href="https://www.stackoverflow.com/users/{{ author.stackoverflow }}" itemprop="sameAs">
+          <i class="fa fa-fw fa-stack-overflow" aria-hidden="true"></i> 
+          Stackoverflow
+        </a></li>
       {% endif %}
       {% if author.lastfm %}
-        <li><a href="https://last.fm/user/{{ author.lastfm }}"><i class="fa fa-fw fa-lastfm-square" aria-hidden="true"></i> Last.fm</a></li>
+        <li><a href="https://last.fm/user/{{ author.lastfm }}" itemprop="sameAs">
+          <i class="fa fa-fw fa-lastfm-square" aria-hidden="true"></i> 
+          Last.fm
+        </a></li>
       {% endif %}
       {% if author.dribbble %}
-        <li><a href="https://dribbble.com/{{ author.dribbble }}"><i class="fa fa-fw fa-dribbble" aria-hidden="true"></i> Dribbble</a></li>
+        <li><a href="https://dribbble.com/{{ author.dribbble }}" itemprop="sameAs">
+          <i class="fa fa-fw fa-dribbble" aria-hidden="true"></i> 
+          Dribbble
+        </a></li>
       {% endif %}
       {% if author.pinterest %}
-        <li><a href="https://www.pinterest.com/{{ author.pinterest }}"><i class="fa fa-fw fa-pinterest" aria-hidden="true"></i> Pinterest</a></li>
+        <li><a href="https://www.pinterest.com/{{ author.pinterest }}" itemprop="sameAs">
+          <i class="fa fa-fw fa-pinterest" aria-hidden="true"></i> 
+          Pinterest
+        </a></li>
       {% endif %}
       {% if author.foursquare %}
-        <li><a href="https://foursquare.com/{{ author.foursquare }}"><i class="fa fa-fw fa-foursquare" aria-hidden="true"></i> Foursquare</a></li>
+        <li><a href="https://foursquare.com/{{ author.foursquare }}" itemprop="sameAs">
+          <i class="fa fa-fw fa-foursquare" aria-hidden="true"></i> 
+          Foursquare
+        </a></li>
       {% endif %}
       {% if author.steam %}
-        <li><a href="https://steamcommunity.com/id/{{ author.steam }}"><i class="fa fa-fw fa-steam-square" aria-hidden="true"></i> Steam</a></li>
+        <li><a href="https://steamcommunity.com/id/{{ author.steam }}" itemprop="sameAs">
+          <i class="fa fa-fw fa-steam-square" aria-hidden="true"></i> 
+          Steam
+        </a></li>
       {% endif %}
       {% if author.youtube %}
-        <li><a href="https://www.youtube.com/user/{{ author.youtube }}"><i class="fa fa-fw fa-youtube-square" aria-hidden="true"></i> YouTube</a></li>
+        <li><a href="https://www.youtube.com/user/{{ author.youtube }}" itemprop="sameAs">
+          <i class="fa fa-fw fa-youtube-square" aria-hidden="true"></i> 
+          YouTube
+        </a></li>
       {% endif %}
       {% if author.soundcloud %}
-        <li><a href="https://soundcloud.com/{{ author.soundcloud }}"><i class="fa fa-fw fa-soundcloud" aria-hidden="true"></i> Soundcloud</a></li>
+        <li><a href="https://soundcloud.com/{{ author.soundcloud }}" itemprop="sameAs">
+          <i class="fa fa-fw fa-soundcloud" aria-hidden="true"></i> 
+          Soundcloud
+        </a></li>
       {% endif %}
       {% if author.weibo %}
-        <li><a href="https://www.weibo.com/{{ author.weibo }}"><i class="fa fa-fw fa-weibo" aria-hidden="true"></i> Weibo</a></li>
+        <li><a href="https://www.weibo.com/{{ author.weibo }}" itemprop="sameAs">
+          <i class="fa fa-fw fa-weibo" aria-hidden="true"></i> 
+          Weibo
+        </a></li>
       {% endif %}
       {% if author.flickr %}
-        <li><a href="https://www.flickr.com/{{ author.flickr }}"><i class="fa fa-fw fa-flickr" aria-hidden="true"></i> Flickr</a></li>
+        <li><a href="https://www.flickr.com/{{ author.flickr }}" itemprop="sameAs">
+          <i class="fa fa-fw fa-flickr" aria-hidden="true"></i> 
+          Flickr
+        </a></li>
       {% endif %}
       {% if author.codepen %}
-        <li><a href="https://codepen.io/{{ author.codepen }}"><i class="fa fa-fw fa-codepen" aria-hidden="true"></i> CodePen</a></li>
+        <li><a href="https://codepen.io/{{ author.codepen }}" itemprop="sameAs">
+          <i class="fa fa-fw fa-codepen" aria-hidden="true"></i> 
+          CodePen
+        </a></li>
       {% endif %}
       {% if author.vine %}
-        <li><a href="https://vine.co/u/{{ author.vine }}"><i class="fa fa-fw fa-vine" aria-hidden="true"></i> Vine</a></li>
+        <li><a href="https://vine.co/u/{{ author.vine }}" itemprop="sameAs">
+          <i class="fa fa-fw fa-vine" aria-hidden="true"></i> 
+          Vine
+        </a></li>
       {% endif %}
     </ul>
   </div>


### PR DESCRIPTION
Adds schema.org properties for the `itemtype="http://schema.org/Person" ` in the file ['_includes/author-profile.html'](https://github.com/mmistakes/minimal-mistakes/blob/master/_includes/author-profile.html). The following properties were added: 

- `image` for `author.avatar`
- `name` for `author.name`
- `description` for `author.bio`
- `homeLocation` (adds a `itemtype="http://schema.org/Place"` with `itemprop="name"` for `author.location` )
- `url` for `author.uri`
- `email` for `author.email`
- `sameAs` for all the social media links

As the schema.org attributes added made the lines of text longer, I also modified some of the indentation so the html source is a bit easier to understand. 

This lets Google's Crawler see all the structured data (this can be tested at using [Google's Structured Data Testing Tool](https://search.google.com/structured-data/testing-tool). )