### PR TITLE
Upgrades Schema Metadata

### DIFF
--- a/_includes/author-profile.html
+++ b/_includes/author-profile.html
@@ -4,7 +4,7 @@
   {% assign author = site.author %}
 {% endif %}
 
-<div itemscope itemtype="http://schema.org/Person">
+<div itemprop="author" itemscope itemtype="http://schema.org/Person">
 
   {% if author.avatar %}
     <div class="author__avatar">

--- a/_includes/seo.html
+++ b/_includes/seo.html
@@ -125,9 +125,67 @@
     {
       "@context" : "http://schema.org",
       "@type" : "{% if site.social.type %}{{ site.social.type }}{% else %}Person{% endif %}",
-      "name" : "{{ site.social.name | default: site.name }}",
-      "url" : {{ seo_url | jsonify }},
-      "sameAs" : {{ site.social.links | jsonify }}
+      
+      {% if site.social.name %}
+        "name" : {{ site.social.name}},
+        "sameAs" : {{ site.social.links | jsonify }},
+        "url" : {{ seo_url | jsonify }}
+      {% else %}
+      
+        "name" : "{{ seo_author.name }}",
+        {% if seo_author.avatar %}
+        "image" : "{{ seo_author.avatar | absolute_url }}",
+        {% endif %}      
+        {% if seo_author.email %}
+        "email" : "{{ seo_author.email }}",
+        {% endif %}      
+        {% if seo_author.location %}
+        "homeLocation" : { "@type" : "Place",
+                           "name" : "{{ seo_author.location }}"
+                         },
+        {% endif %}  
+        {% if seo_author.bio %}
+        "description" : "{{ seo_author.bio }}",
+        {% endif %}
+        
+        "sameAs " : [
+          {% capture seo_social_media %}
+            {% if seo_author.facebook %}
+              "https://www.facebook.com/{{ seo_author.facebook }}",
+            {% endif %}
+            {% if seo_author.twitter %}
+              "https://twitter.com/{{ seo_author.twitter }}",
+            {% endif %}
+            {% if seo_author.google_plus %}
+              "https://plus.google.com/+{{ seo_author.google_plus }}",
+            {% endif %}
+            {% if seo_author.instagram %}
+              "https://instagram.com/{{ seo_author.instagram }}",
+            {% endif %}
+            {% if seo_author.youtube %}
+              "https://www.youtube.com/user/{{ seo_author.youtube }}",
+            {% endif %}
+            {% if seo_author.linkedin %}
+              "https://www.linkedin.com/in/{{ seo_author.linkedin }}",
+            {% endif %}
+            {% if seo_author.pinterest %}
+              "https://www.pinterest.com/{{ seo_author.pinterest }}",
+            {% endif %}
+            {% if seo_author.soundcloud %}
+              "https://soundcloud.com/{{ seo_author.soundcloud }}",
+            {% endif %}
+            {% if seo_author.tumblr %}
+              "https://{{ seo_author.tumblr }}.tumblr.com",
+            {% endif %}
+          {% endcapture %}
+          {{ seo_social_media | split: '' | reverse | join: '' 
+                              | remove_first: ','
+                              | split: '' | reverse | join: ''
+          }}
+        ],
+        
+        "url" : "{{ seo_author.uri | default: seo_url }}"
+      {% endif %}
     }
   </script>
 {% endif %}

--- a/_includes/seo.html
+++ b/_includes/seo.html
@@ -25,7 +25,8 @@
 
 <meta name="description" content="{{ seo_description }}">
 
-{% assign seo_author = page.author | default: page.author[0] | default: site.author[0] %}
+{% assign seo_author = page.author | default: page.author[0] 
+                       | default: site.author[0] | default: site.author%}
 {% if seo_author %}
   {% if seo_author.twitter %}
     {% assign seo_author_twitter = seo_author.twitter %}

--- a/_includes/seo.html
+++ b/_includes/seo.html
@@ -108,6 +108,7 @@
   <link rel="next" href="{{ paginator.next_page_path | prepend: seo_url }}">
 {% endif %}
 
+
 {% if site.og_image %}
   <script type="application/ld+json">
     {
@@ -130,6 +131,16 @@
     }
   </script>
 {% endif %}
+  
+<script type="application/ld+json">
+  {
+    "@context" : "http://schema.org",
+    "@type" : "WebSite",
+    "name" : "{{ site.name }}",
+    "url" : {{ seo_url | jsonify }},
+    "description" : "{{ seo_description}}"
+  }
+</script>
 
 {% if site.google_site_verification %}
   <meta name="google-site-verification" content="{{ site.google_site_verification }}" />

--- a/_layouts/single.html
+++ b/_layouts/single.html
@@ -13,9 +13,10 @@ layout: default
 {% endif %}
 
 <div id="main" role="main">
+  <div itemscope itemtype="http://schema.org/CreativeWork">
   {% include sidebar.html %}
 
-  <article class="page" itemscope itemtype="http://schema.org/CreativeWork">
+  <article class="page">
     {% if page.title %}<meta itemprop="headline" content="{{ page.title | markdownify | strip_html | strip_newlines | escape_once }}">{% endif %}
     {% if page.excerpt %}<meta itemprop="description" content="{{ page.excerpt | markdownify | strip_html | strip_newlines | escape_once }}">{% endif %}
     {% if page.date %}<meta itemprop="datePublished" content="{{ page.date | date: "%B %d, %Y" }}">{% endif %}
@@ -57,6 +58,7 @@ layout: default
       {% include comments.html %}
     {% endif %}
   </article>
+  </div>
 
   {% comment %}<!-- only show related on a post page when not disabled -->{% endcomment %}
   {% if page.id and page.related and site.related_posts.size > 0 %}


### PR DESCRIPTION
### This pull request upgrades Schema Metadata to better allow Google Search to parse data in the website.

Firstly in 23af38b, it changes the [`_includes/author-profile.html`](https://github.com/mmistakes/minimal-mistakes/blob/master/_includes/author-profile.html) file so that the author-profile has the Schema `itemprop="author"`. This does not affect anything, except when a page uses `layout: single`. In this case, the page's `CreativeWork` Schema object will list the author-profile as the `author` of the `CreativeWork`.

Secondly in b9f07ac, the `seo_author` field in [`_includes/seo.html`](https://github.com/mmistakes/minimal-mistakes/blob/master/_includes/seo.html) becomes `site.author` if none of the other fields are filled. 
Before, the last value it would try to take was `site.author[0]`. However, in the default [`_config.yml`](https://github.com/mmistakes/minimal-mistakes/blob/master/_config.yml) file, `site.author` is not an array. So the code has been changed so that if `site.author[0]` is null, `site.author` will be used instead.

Thirdly in 	878100d, some Schema details of type `WebSite` were added to [`_includes/seo.html`](https://github.com/mmistakes/minimal-mistakes/blob/master/_includes/seo.html). This should [allow Google to add the site-name to search results](https://developers.google.com/search/docs/data-types/sitename).

Finally in 	9456f0c, the Schema details of type `{% if site.social.type %}{{ site.social.type }}{% else %}Person{% endif %}` were modified, so that if `site.social.name` was not set, schema information would be set using the `seo_author` field. All of the fields added are almost exactly the same as the Schema fields in [`_includes/author-profile.html`](https://github.com/mmistakes/minimal-mistakes/blob/master/_includes/author-profile.html), however, only [the social profiles that Google Search supports](https://developers.google.com/search/docs/data-types/social-profile-links) were added.