### PR TITLE
Fix Discourse noscript link

### DIFF
--- a/_includes/comments-providers/discourse.html
+++ b/_includes/comments-providers/discourse.html
@@ -9,5 +9,5 @@
      (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(d);
    })();
 </script>
-<noscript>Please enable JavaScript to view the comments powered by [Discourse](http://forum.beta-europe.org/c/beta/website).</a></noscript>
+<noscript>Please enable JavaScript to view the comments powered by <a href="https://www.discourse.org/">Discourse.</a></noscript>
 {% endif %}


### PR DESCRIPTION
# What does this PR do?

 - Changes the link in the Discourse comments template, `<noscript>` section, to point to the Discourse.org homepage instead of a specific instance of Discourse (beta-europe.org).

# Why?

This has been changed because the original "link" looks like a mistake:

- It does not appear to be related to this project,
- It is in Markdown format - Markdown is not parsed in this `.html` partial, and,
- There is a stray `</a>` tag after it.