### PR TITLE
Pagination now works for index.html files in subfolders.

### DIFF
--- a/_includes/paginator.html
+++ b/_includes/paginator.html
@@ -60,7 +60,7 @@
 
     {% comment %} Link next page {% endcomment %}
     {% if paginator.next_page %}
-      <li><a href="{{ paginator.next_page_path }}">{{ site.data.ui-text[site.locale].pagination_next | default: "Next" }}</a></li>
+      <li><a href="{{ site.paginate_path | replace: ':num', paginator.next_page | replace: '//', '/' | absolute_url }}">{{ site.data.ui-text[site.locale].pagination_next | default: "Next" }}</a></li></a></li>
     {% else %}
       <li><a href="#" class="disabled"><span aria-hidden="true">{{ site.data.ui-text[site.locale].pagination_next | default: "Next" }}</span></a></li>
     {% endif %}

--- a/_includes/paginator.html
+++ b/_includes/paginator.html
@@ -1,22 +1,23 @@
 {% if paginator.total_pages > 1 %}
 <nav class="pagination">
+  {% assign first_page_path = site.paginate_path | replace: 'page:num', '' | replace: '//', '/' | absolute_url %}
   <ul>
     {% comment %} Link for previous page {% endcomment %}
     {% if paginator.previous_page %}
       {% if paginator.previous_page == 1 %}
-        <li><a href="{{ '/' | absolute_url }}">{{ site.data.ui-text[site.locale].pagination_previous | default: "Previous" }}</a></li>
+        <li><a href="{{ first_page_path }}">{{ site.data.ui-text[site.locale].pagination_previous | default: "Previous" }}</a></li>
       {% else %}
-        <li><a href="{{ '/page' | absolute_url }}{{ paginator.previous_page | append: '/' }}">{{ site.data.ui-text[site.locale].pagination_previous | default: "Previous" }}</a></li>
+        <li><a href="{{ site.paginate_path | replace: ':num', paginator.previous_page | replace: '//', '/' | absolute_url }}">{{ site.data.ui-text[site.locale].pagination_previous | default: "Previous" }}</a></li>
       {% endif %}
     {% else %}
-      <li><a href="#" class="disabled"><span aria-hidden="true">{{ site.data.ui-text[site.locale].pagination_previous | default: "Previous" }}</span></a></li>
+    <li><a href="#" class="disabled"><span aria-hidden="true">{{ site.data.ui-text[site.locale].pagination_previous | default: "Previous" }}</span></a></li>
     {% endif %}
 
     {% comment %} First page {% endcomment %}
     {% if paginator.page == 1 %}
       <li><a href="#" class="disabled current">1</a></li>
     {% else %}
-      <li><a href="{{ '/' | absolute_url }}">1</a></li>
+      <li><a href="{{ first_page_path }}">1</a></li>
     {% endif %}
 
     {% assign page_start = 2 %}
@@ -34,7 +35,7 @@
 
     {% for index in (page_start..page_end) %}
       {% if index == paginator.page %}
-        <li><a href="{{ '/page' | absolute_url }}{{ index | append: '/' }}" class="disabled current">{{ index }}</a></li>
+        <li><a href="{{ site.paginate_path | replace: ':num', index | replace: '//', '/' | absolute_url }}" class="disabled current">{{ index }}</a></li>
       {% else %}
         {% comment %} Distance from current page and this link {% endcomment %}
         {% assign dist = paginator.page | minus: index %}
@@ -42,7 +43,7 @@
           {% comment %} Distance must be a positive value {% endcomment %}
           {% assign dist = 0 | minus: dist %}
         {% endif %}
-        <li><a href="{{ '/page' | absolute_url }}{{ index | append: '/' }}">{{ index }}</a></li>
+        <li><a href="{{ site.paginate_path | replace: ':num', index | absolute_url }}">{{ index }}</a></li>
       {% endif %}
     {% endfor %}
 
@@ -54,12 +55,12 @@
     {% if paginator.page == paginator.total_pages %}
       <li><a href="#" class="disabled current">{{ paginator.page }}</a></li>
     {% else %}
-      <li><a href="{{ '/page' | absolute_url }}{{ paginator.total_pages }}/">{{ paginator.total_pages }}</a></li>
+      <li><a href="{{ site.paginate_path | replace: ':num', paginator.total_pages | replace: '//', '/' | absolute_url }}">{{ paginator.total_pages }}</a></li>
     {% endif %}
 
     {% comment %} Link next page {% endcomment %}
     {% if paginator.next_page %}
-      <li><a href="{{ '/page' | absolute_url }}{{ paginator.next_page }}/">{{ site.data.ui-text[site.locale].pagination_next | default: "Next" }}</a></li>
+      <li><a href="{{ paginator.next_page_path }}">{{ site.data.ui-text[site.locale].pagination_next | default: "Next" }}</a></li>
     {% else %}
       <li><a href="#" class="disabled"><span aria-hidden="true">{{ site.data.ui-text[site.locale].pagination_next | default: "Next" }}</span></a></li>
     {% endif %}


### PR DESCRIPTION
I wanted to use the minimal-mistakes theme for a blog with a landing page. Hence, I've used the splash layout for the index.html page in the root folder and I've created a subfolder named blog containing another index.html file. The latter index.html file should show the most recent blog posts and it should also paginate them. That wasn't possible using the original paginator.html file, because it did not use the paginate_path variable.