### PR TITLE
Add https:// prefix to google-universal.html embed code

### DIFF
--- a/_includes/analytics-providers/google-universal.html
+++ b/_includes/analytics-providers/google-universal.html
@@ -2,7 +2,7 @@
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
   (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
   m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 
   ga('create', '{{ site.analytics.google.tracking_id }}', 'auto');
   ga('send', 'pageview');


### PR DESCRIPTION
The google universal analytics embed code looks to be slightly different now, including an https before the url to the analytics script.