### PR TITLE
Add responsive video header and include with docs

### DIFF
--- a/_includes/page__hero_video.html
+++ b/_includes/page__hero_video.html
@@ -1,0 +1,4 @@
+{% capture video_id %}{{ page.header.video.id }}{% endcapture %}
+{% capture video_provider %}{{ page.header.video.provider }}{% endcapture %}
+
+{% include responsive_video id=video_id provider=video_provider %}

--- a/_includes/responsive_video
+++ b/_includes/responsive_video
@@ -1,0 +1,11 @@
+{% capture video_id %}{{ include.id }}{% endcapture %}
+{% capture video_provider %}{{ include.provider }}{% endcapture %}
+
+<!-- Courtesy of embedresponsively.com //-->
+<div class="responsive-video-container">
+{% if video_provider == "vimeo" %}
+  <iframe src="http://player.vimeo.com/video/{{ video_id }}" frameborder="0" webkitAllowFullScreen mozallowfullscreen allowFullScreen></iframe>
+{% elsif video_provider == "youtube" %}
+  <iframe src="https://www.youtube.com/embed/{{ video_id }}" frameborder="0" allowfullscreen></iframe>
+{% endif %}
+</div>

--- a/_layouts/single.html
+++ b/_layouts/single.html
@@ -4,6 +4,8 @@ layout: default
 
 {% if page.header.overlay_color or page.header.overlay_image or page.header.image %}
   {% include page__hero.html %}
+{% elsif page.header.video.id and page.header.video.provider %}
+  {% include page__hero_video.html %}
 {% endif %}
 
 {% if page.url != "/" and site.breadcrumbs %}

--- a/_sass/_utilities.scss
+++ b/_sass/_utilities.scss
@@ -480,3 +480,26 @@ a.reversefootnote {
     border: 0; /* remove table borders widget */
   }
 }
+
+/*
+   Responsive Video Embed
+      ========================================================================== */
+
+.responsive-video-container {
+  position: relative;
+  padding-bottom: 56.25%;
+  height: 0;
+  overflow: hidden;
+  max-width: 100%;
+
+  iframe,
+  object,
+  embed {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+  }
+}
+

--- a/docs/_docs/14-helpers.md
+++ b/docs/_docs/14-helpers.md
@@ -189,6 +189,16 @@ And then drop-in the feature row include in the body where you'd like it to appe
 **More Feature Row Goodness:** A [few more examples]({{ "/splash-page/" | absolute_url }}) and [source code](https://github.com/{{ site.repository }}/blob/master/docs/_pages/splash-page.md) can be seen in the demo site.
 {: .notice--info}
 
+## Video
+
+Embed a responsive video from YouTube or Vimeo.
+
+```liquid
+{% raw %}{% include responsive_video id="97649261" provider="vimeo" %}{% endraw %}
+```
+
+{% include responsive_video id="97649261" provider="vimeo" %}
+
 ## Table of Contents
 
 To include an [auto-generated table of contents](http://kramdown.rubyforge.org/converter/html.html#toc) for posts and pages, add the following helper before any actual content in your post or page.

--- a/docs/_includes/page__hero_video.html
+++ b/docs/_includes/page__hero_video.html
@@ -1,0 +1,4 @@
+{% capture video_id %}{{ page.header.video.id }}{% endcapture %}
+{% capture video_provider %}{{ page.header.video.provider }}{% endcapture %}
+
+{% include responsive_video id=video_id provider=video_provider %}

--- a/docs/_includes/responsive_video
+++ b/docs/_includes/responsive_video
@@ -1,0 +1,11 @@
+{% capture video_id %}{{ include.id }}{% endcapture %}
+{% capture video_provider %}{{ include.provider }}{% endcapture %}
+
+<!-- Courtesy of embedresponsively.com //-->
+<div class="responsive-video-container">
+{% if video_provider == "vimeo" %}
+  <iframe src="http://player.vimeo.com/video/{{ video_id }}" frameborder="0" webkitAllowFullScreen mozallowfullscreen allowFullScreen></iframe>
+{% elsif video_provider == "youtube" %}
+  <iframe src="https://www.youtube.com/embed/{{ video_id }}" frameborder="0" allowfullscreen></iframe>
+{% endif %}
+</div>

--- a/docs/_layouts/single.html
+++ b/docs/_layouts/single.html
@@ -4,6 +4,8 @@ layout: default
 
 {% if page.header.overlay_color or page.header.overlay_image or page.header.image %}
   {% include page__hero.html %}
+{% elsif page.header.video.id and page.header.video.provider %}
+  {% include page__hero_video.html %}
 {% endif %}
 
 {% if page.url != "/" and site.breadcrumbs %}

--- a/docs/_posts/2017-01-23-layout-header-video.md
+++ b/docs/_posts/2017-01-23-layout-header-video.md
@@ -1,0 +1,51 @@
+---
+title: "Layout: Header Video"
+header:
+  video:
+    id: XsxDH4HcOWA
+    provider: youtube
+categories:
+  - Layout
+  - Uncategorized
+tags:
+  - video
+  - layout
+---
+
+This post should display a **header with a reponsive video**, if the theme supports it.
+
+## Settings
+
+|---
+| Parameter | Required | Description |
+|-|-
+| `id` | **Required** | ID of the video
+| `provider` | **Required** | Hosting provider of the video, either 'youtube' or 'vimeo'
+|---
+
+## YouTube
+
+Here is a YouTube example for the video at url `https://www.youtube.com/watch?v=XsxDH4HcOWA` (long version) or `https://youtu.be/XsxDH4HcOWA` (short version):
+
+```yaml
+header:
+  video:
+    id: XsxDH4HcOWA
+    provider: youtube
+```
+
+{% include responsive_video id="XsxDH4HcOWA" provider="youtube" %}
+
+## Vimeo
+
+Here is a Vimeo example for the video at url `https://vimeo.com/97649261`:
+
+```yaml
+header:
+  video:
+    id: 97649261
+    provider: vimeo
+```
+
+{% include responsive_video id="97649261" provider="vimeo" %}
+

--- a/docs/_sass/_utilities.scss
+++ b/docs/_sass/_utilities.scss
@@ -480,3 +480,26 @@ a.reversefootnote {
     border: 0; /* remove table borders widget */
   }
 }
+
+/*
+   Responsive Video Embed
+      ========================================================================== */
+
+.responsive-video-container {
+  position: relative;
+  padding-bottom: 56.25%;
+  height: 0;
+  overflow: hidden;
+  max-width: 100%;
+
+  iframe,
+  object,
+  embed {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+  }
+}
+


### PR DESCRIPTION
Follow-up fixes for #781:

1. Submit pull request against the develop branch and not master. 
2. Fix indenting in (2 space vs. 4)
3. Move inline CSS to Sass partial (_sass/_utlities.scss)
4. Replace apostrophes with double quotes ie: <div class="embed-container"> instead of <div class='embed-container'>

Additional enhancements:

1. Refactored embed video from `_includes/page__hero_video.html` into `_includes/responsive_video`
2. Updated `_includes/page__hero_video.html` to use `{% include responsive_video id="..." provider="..." %}`
3. Updated documentation with 1) blog post for layout with header video, and 2) new "Video" section in the Helpers documentation.

Let me know if there's any further modifications required for merging. Thanks! =)