### PR TITLE
Add medium connector

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -101,6 +101,7 @@ author:
   steam            :
   tumblr           :
   twitter          :
+  medium           :
   vine             :
   weibo            :
   xing             :

--- a/_includes/author-profile.html
+++ b/_includes/author-profile.html
@@ -67,6 +67,14 @@
         </li>
       {% endif %}
 
+      {% if author.medium %}
+        <li>
+          <a href="https://medium.com/@{{ author.medium }}" itemprop="sameAs">
+            <i class="fa fa-fw fa-medium" aria-hidden="true"></i> Medium
+          </a>
+        </li>
+      {% endif %}
+
       {% if author.facebook %}
         <li>
           <a href="https://www.facebook.com/{{ author.facebook }}" itemprop="sameAs">


### PR DESCRIPTION
Sometimes people blog over the internet and want to link it on personal blog pages.