### PR TITLE
Changing translation in pt-br

### DIFF
--- a/_data/ui-text.yml
+++ b/_data/ui-text.yml
@@ -235,8 +235,8 @@ pt-BR:
   menu_label                 :
   toc_label                  : "Nesta página"
   ext_link_label             : "Link direto"
-  less_than                  : "meno que"
-  minute_read                : "minutos de leitura"
+  less_than                  : "menos que"
+  minute_read                : "minuto(s) de leitura"
   share_on_label             : "Compartilhe em"
   meta_label                 :
   tags_label                 : "Tags:"
@@ -244,8 +244,8 @@ pt-BR:
   date_label                 : "Atualizado em:"
   comments_label             : "Deixe um comentário"
   comments_title             :
-  more_label                 : "Aprenda Mais"
-  related_label              : "Você Talvez Goste Também"
+  more_label                 : "Aprenda mais"
+  related_label              : "Talvez você goste também"
   follow_label               : "Acompanhe em"
   feed_label                 : "Feed"
   powered_by                 : "Feito com"


### PR DESCRIPTION
There are some issues in the brazilian portuguese translation:
```  
less_than                  : "meno que" 
```
the word "meno" doesn't exist in the language, the correct translation is "menos"
```
  minute_read                : "minutos de leitura" 
```
once we can one or more minutes of reading, the plural of the word "minuto" is optional, so we can use "(s)" after the word "minuto" to reflect this

```
 related_label              : "Você Talvez Goste Também" 
```
this change is for better reading, the previous translation is not good

I changed the capitalization of the subsequent words for lowercase to have default capitalization in all translations.
You can see the results of this translation in my personal blog, [pierryangelo.github.io](pierryangelo.github.io)

Thanks.