### PR TITLE
Improve the documentation for novice users (Tags+Categories and Pagination)

### DIFF
--- a/docs/_docs/05-configuration.md
+++ b/docs/_docs/05-configuration.md
@@ -524,14 +524,14 @@ paginate: 5
 
 You'll also need to include some Liquid and HTML to properly use the paginator, which you can find in the **Layouts** section under [Home Page]({{ "/docs/layouts/#home-page" | absolute_url }}).
 
-**Please note:** [Jekyll's pagination](http://jekyllrb.com/docs/pagination/) may have unexpected results when used on pages other than the home page eg. `<site domain>/blog/index.html`.
-{: .notice--info}
-
-The paginator works only on files with name `index.html`. To show recent files from `/recent/` created a file `/recent/index.html` and set the `paginate_path` in the configuration like this:
+The paginator only works on files with name `index.html`. To use pagination in a subfolder --- for example `/recent/`, create `/recent/index.html` and set the `paginate_path` in `_config.yml` to this:
 
 ```yaml
 paginate_path: /recent/page:num/
 ```
+
+**Please note:** When using Jekyll's default [pagination plugin](http://jekyllrb.com/docs/pagination/) `paginator.posts` can only be called once. If you're looking for something more powerful that can paginate category, tag, and collection pages I suggest [**jekyll-paginate-v2**](https://github.com/sverrirs/jekyll-paginate-v2).
+{: .notice--info}
 
 ### Timezone
 

--- a/docs/_docs/05-configuration.md
+++ b/docs/_docs/05-configuration.md
@@ -527,6 +527,12 @@ You'll also need to include some Liquid and HTML to properly use the paginator, 
 **Please note:** [Jekyll's pagination](http://jekyllrb.com/docs/pagination/) may have unexpected results when used on pages other than the home page eg. `<site domain>/blog/index.html`.
 {: .notice--info}
 
+The paginator works only on files with name `index.html`. To show recent files from `/recent/` created a file `/recent/index.html` and set the `paginate_path` in the configuration like this:
+
+```yaml
+paginate_path: /recent/page:num/
+```
+
 ### Timezone
 
 This sets the timezone environment variable, which Ruby uses to handle time and date creation and manipulation. Any entry from the [IANA Time Zone Database](http://en.wikipedia.org/wiki/List_of_tz_database_time_zones) is valid. The default is the local time zone, as set by your operating system.

--- a/docs/_docs/10-layouts.md
+++ b/docs/_docs/10-layouts.md
@@ -155,13 +155,20 @@ To produce something like this:
 
 ### Taxonomy Archive
 
-If you have the luxury of using Jekyll plugins the creation of category and tag archives is greatly simplified. Enable support for the [`jekyll-archives`](https://github.com/jekyll/jekyll-archives) plugin with a few `_config.yml` settings as noted in the [**Configuration**]({{ "/docs/configuration/#archive-settings" | absolute_url }}) section.
+If you have the luxury of using Jekyll plugins, the creation of category and tag archives is greatly simplified. Simply enable support for the [`jekyll-archives`](https://github.com/jekyll/jekyll-archives) plugin with a few `_config.yml` settings as noted in the [**Configuration**]({{ "/docs/configuration/#archive-settings" | absolute_url }}) section and you're good to go.
 
 ![archive taxonomy layout example]({{ "/assets/images/mm-layout-archive-taxonomy.png" | absolute_url }})
 
-If you don't then you need to create the pages yourself. Create the `_pages/tag-archive.html` and `_pages/category-archive.html`. This is an example of a page for tags that responds to urls such as `/tags/#tips`:
+If you're not using the `jekyll-archives` plugin then you need to create archive pages yourself. Sample taxonomy archives can be found by grabbing the HTML sources below and adding to your site.
 
-```text
+| Name                 | HTML Source |
+| -------------------- | --- |
+| [Categories Archive](https://mmistakes.github.io/minimal-mistakes/categories/) | [category-archive.html](https://github.com/mmistakes/minimal-mistakes/blob/master/docs/_pages/category-archive.html) |
+| [Tags Archive](https://mmistakes.github.io/minimal-mistakes/tags/) | [tag-archive.html](https://github.com/mmistakes/minimal-mistakes/blob/master/docs/_pages/tag-archive.html) |
+
+The **Tags Archive** page that responds to urls such as `/tags/#tips` looks something like this:
+
+```html
 ---
 layout: archive
 permalink: /tags/

--- a/docs/_docs/10-layouts.md
+++ b/docs/_docs/10-layouts.md
@@ -159,6 +159,27 @@ If you have the luxury of using Jekyll plugins the creation of category and tag 
 
 ![archive taxonomy layout example]({{ "/assets/images/mm-layout-archive-taxonomy.png" | absolute_url }})
 
+If you don't then you need to create the pages yourself. Create the `_pages/tag-archive.html` and `_pages/category-archive.html`. This is an example of a page for tags that responds to urls such as `/tags/#tips`:
+
+```text
+---
+layout: archive
+permalink: /tags/
+title: "Posts by Tags"
+author_profile: true
+---
+
+{% include group-by-array collection=site.posts field="tags" %}
+
+{% for tag in group_names %}
+  {% assign posts = group_items[forloop.index0] %}
+  <h2 id="{{ tag | slugify }}" class="archive__subtitle">{{ tag }}</h2>
+  {% for post in posts %}
+    {% include archive-single.html %}
+  {% endfor %}
+{% endfor %}
+```
+
 ### Home Page
 
 A derivative archive page layout to be used as a simple home page. It is built to show a paginated list of recent posts based off of the [pagination settings]({{ "/docs/configuration/#paginate" | absolute_url }}) in `_config.yml`.


### PR DESCRIPTION
First of all let me thank @mmistakes for helping me out with some issues I had.
I've noticed that the documentation puts some effort initially to help the novice user but on some subjects fails to help out. 
I've documented all my experience [Novice guide for Jekyll on Windows and github pages](https://sarafian.github.io/tips/2017/02/08/Novice-guide-to-run-Jekyll-on-Windows-and-github-pages.html) and I would like to contribute the relevant information.