### PR TITLE
meta tag "author" added, for site author the field name is used

### DIFF
--- a/_includes/seo.html
+++ b/_includes/seo.html
@@ -25,7 +25,7 @@
 
 <meta name="description" content="{{ seo_description }}">
 
-{% assign seo_author = page.author | default: page.author[0] | default: site.author[0] %}
+{% assign seo_author = page.author | default: page.author[0] | default: site.author.name %}
 {% if seo_author %}
   {% if seo_author.twitter %}
     {% assign seo_author_twitter = seo_author.twitter %}
@@ -38,6 +38,8 @@
   {% endif %}
   {% assign seo_author_twitter = seo_author_twitter | replace: "@", "" %}
 {% endif %}
+
+<meta name="author" content="{{ seo_author }}">
 
 <meta property="og:locale" content="{{ site.locale | replace: "-", "_" | default: "en" }}">
 <meta property="og:site_name" content="{{ site.title }}">


### PR DESCRIPTION
I added the meta tag author which was missing.

In case of fallback to site author, seo_author is now assigned to site.author.name instead of site.author[0] which always produced an empty string.