### PR TITLE
[Proposal] Go "serve-ready" with JekyllPlus

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -6,6 +6,8 @@
 # `jekyll serve`. If you change this file, please restart the server process.
 
 # Site Settings
+theme                    : "minimal-mistakes-jekyll" # disable this line when using the GitHub Pages Compatible Method to install this theme.
+
 locale                   : "en"
 title                    : "Site Title"
 title_separator          : "-"

--- a/_config.yml
+++ b/_config.yml
@@ -244,3 +244,10 @@ defaults:
       comments: # true
       share: true
       related: true
+  # all Jekyll Pages and _pages collection
+  - scope:
+      path: ""
+      type: pages
+    values:
+      layout: single
+      author_profile: true

--- a/docs/_docs/01-quick-start-guide.md
+++ b/docs/_docs/01-quick-start-guide.md
@@ -45,6 +45,8 @@ bundle install
 
 Fork the [Minimal Mistakes theme](https://github.com/mmistakes/minimal-mistakes/fork), then rename the repo to **USERNAME.github.io** --- replacing **USERNAME** with your GitHub username.
 
+Delete or disable the line with `theme:` key in the default `_config.yml` (Simply add a `#` at the starting of the line.)
+
 <figure>
   <img src="{{ '/assets/images/mm-theme-fork-repo.png' | absolute_url }}" alt="fork Minimal Mistakes">
 </figure>

--- a/docs/_docs/01-quick-start-guide.md
+++ b/docs/_docs/01-quick-start-guide.md
@@ -95,6 +95,38 @@ If you forked or downloaded the `minimal-mistakes-jekyll` repo you can safely re
 
 Depending on the path you took installing Minimal Mistakes you'll setup things a little differently.
 
+### Bootstrapping and Serving the Theme-Gem with JekyllPlus
+
+JekyllPlus is a Ruby gem developed to simplify the setup and serving of Jekyll Sites with gem-based Themes that have template files within the `_data` directory, and a custom config file.<br/>
+
+  1. Install the latest **serve-ready** (> v4.2.2) version of Minimal-Mistakes theme-gem (if you did not already) and the JekyllPlus gem:
+
+  ```sh
+  # Install the 2 gems in one stretch
+  #
+  $ gem install minimal-mistakes-jekyll jekyll-plus
+
+  # or just the jekyll-plus gem
+  #
+  $ gem install jekyll-plus
+  ```
+
+  2. Install your new Jekyll Site locally with JekyllPlus' `new-site` command
+
+  ```
+  $ jekyll+ new-site my-blog --theme minimal-mistakes-jekyll
+  ```
+
+  3. Build / Serve your new site with JekyllPlus
+
+  ```
+  $ bundle exec jekyll+ serve
+  ```
+
+And there.. you're all set to edit and preview your Jekyll Site at `http://localhost:4000`.<br/>
+What JekyllPlus did was to automatically configure the Gemfile to use this theme and the `jekyll-plus` plugin, and, additionally installed the [Minimal Mistakes Configuration file](https://github.com/mmistakes/minimal-mistakes/blob/master/_config.yml) for you.
+
+
 ### Starting Fresh
 
 Starting with an empty folder and `Gemfile` you'll need to copy or re-create this [default `_config.yml`](https://github.com/mmistakes/minimal-mistakes/blob/master/_config.yml) file. For a full explanation of every setting be sure to read the [**Configuration**]({{ "/docs/configuration/" | absolute_url }}) section.

--- a/docs/_docs/05-configuration.md
+++ b/docs/_docs/05-configuration.md
@@ -22,6 +22,8 @@ If you're using the Ruby gem version of the theme you'll need this line to activ
 theme: minimal-mistakes-jekyll
 ```
 
+Included by default, you'll have to remove or disable it if not using the gem-based version.
+
 ### Site Locale
 
 `site.locale` is used to declare the primary language for each web page within the site.

--- a/minimal-mistakes-jekyll.gemspec
+++ b/minimal-mistakes-jekyll.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.metadata["plugin_type"] = "theme"
 
   spec.files                   = `git ls-files -z`.split("\x0").select do |f|
-    f.match(%r{^(assets|_(includes|layouts|sass)/|(LICENSE|README|CHANGELOG)((\.(txt|md|markdown)|$)))}i)
+    f.match(%r{^(assets|_(data|includes|layouts|sass)/|(_config|LICENSE|README|CHANGELOG)((\.(yml|txt|md|markdown)|$)))}i)
   end
 
   spec.add_runtime_dependency "jekyll", "~> 3.3"


### PR DESCRIPTION
Hi,
In case you haven't dropped the idea of including the `_data` folder within the theme-gem, I propose to upgrade the gem to a **`serve-ready`** status with [**JekyllPlus**](https://github.com/ashmaroli/jekyll-plus)

This pull is mainly intended to generate some interest ahead of the release of `jekyll-plus v0.2.0` slated for 24th Feb and allow this gem to work with JekyllPlus as expected, albeit hopefully from v4.3

### serve-ready ?
From the docs for JekyllPlus v0.2.0:
> Serve-ready theme-gems contain all the minimum elements that are required to let the consumer easily preview their site by simply running **`bundle exec jekyll+ serve`**

This is only possible if the two conditions below are met:
  1. The theme-gem itself bundles the required files/folders &mdash; *addressed by this pull.*
  2. `jekyll-plus` is added to the user's `Gemfile` &mdash; *handled automatically for new projects created with **`jekyll+ new-site`***