### PR TITLE
Allow side-or-corner linear-gradient

### DIFF
--- a/_includes/page__hero.html
+++ b/_includes/page__hero.html
@@ -16,6 +16,9 @@
   {% capture overlay_img_path %}{{ page.header.overlay_image | absolute_url }}{% endcapture %}
 {% endif %}
 
+{% if page.header.overlay_filter contains "to" %}
+  {% assign full_gradient = true %}
+{% endif %}
 {% if page.header.overlay_filter contains "rgba" %}
   {% capture overlay_filter %}{{ page.header.overlay_filter }}{% endcapture %}
 {% elsif page.header.overlay_filter %}
@@ -23,7 +26,7 @@
 {% endif %}
 
 <div class="page__hero{% if page.header.overlay_color or page.header.overlay_image %}--overlay{% endif %}"
-  style="{% if page.header.overlay_color %}background-color: {{ page.header.overlay_color | default: 'transparent' }};{% endif %} {% if overlay_img_path %}background-image: {% if overlay_filter %}linear-gradient({{ overlay_filter }}, {{ overlay_filter }}), {% endif %}url('{{ overlay_img_path }}');{% endif %}"
+  style="{% if page.header.overlay_color %}background-color: {{ page.header.overlay_color | default: 'transparent' }};{% endif %} {% if overlay_img_path %}background-image: {% if full_gradient %}linear-gradient({{ overlay_filter }}), {% elsif overlay_filter %}linear-gradient({{ overlay_filter }}, {{ overlay_filter }}), {% endif %}url('{{ overlay_img_path }}');{% endif %}"
 >
   {% if page.header.overlay_color or page.header.overlay_image %}
     <div class="wrapper">


### PR DESCRIPTION
A fairly simple addition that allows people to use complex side-or-corner style linear-gradients; backwards compatible.  New allowable syntax:
  header:
    overlay_filter: to right, rgba(255, 255, 255, 1.0) 20%, rgba(255, 255, 255, 0) 95%

Let me know if this is 1) efficient enough, and 2) if you think it's worth adding to the base or not.  Even allowing just the "to top right..." syntax allows people a lot more flexibility to shade images or headers in interesting ways.
Thanks!