### PR TITLE
fix(includes/video): use https always

### DIFF
--- a/_includes/video
+++ b/_includes/video
@@ -4,7 +4,7 @@
 <!-- Courtesy of embedresponsively.com //-->
 <div class="responsive-video-container">
 {% if video_provider == "vimeo" %}
-  <iframe src="http://player.vimeo.com/video/{{ video_id }}" frameborder="0" webkitAllowFullScreen mozallowfullscreen allowFullScreen></iframe>
+  <iframe src="https://player.vimeo.com/video/{{ video_id }}" frameborder="0" webkitAllowFullScreen mozallowfullscreen allowFullScreen></iframe>
 {% elsif video_provider == "youtube" %}
   <iframe src="https://www.youtube.com/embed/{{ video_id }}" frameborder="0" allowfullscreen></iframe>
 {% endif %}


### PR DESCRIPTION
when served over https the vimeo link was failing. defer scheme used for video iframe src urls
realtive to the current protocol (e.g. http or https)

closes #944