### PR TITLE
Add sass variable to set default page content alignment

### DIFF
--- a/_sass/_page.scss
+++ b/_sass/_page.scss
@@ -59,6 +59,7 @@
 
   p, li, dl {
     font-size: 1em;
+    text-align: $paragraph-align;
   }
 
   /* paragraph indents */

--- a/_sass/_sidebar.scss
+++ b/_sass/_sidebar.scss
@@ -47,6 +47,10 @@
 .sidebar__right {
   margin-bottom: 1em;
 
+  p, li, dl {
+    text-align: left;
+  }
+
   @include breakpoint($large) {
     position: relative;
     float: right;

--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -12,6 +12,9 @@ $doc-font-size              : 16 !default;
 $paragraph-indent           : false !default; // true, false (default)
 $indent-var                 : 1.3em !default;
 
+/* paragraph alignment */
+$paragraph-align            : left !default; // left (default), right, center, justify
+
 /* system typefaces */
 $serif                      : Georgia, Times, serif !default;
 $sans-serif                 : -apple-system, ".SFNSText-Regular", "San Francisco", "Roboto", "Segoe UI", "Helvetica Neue", "Lucida Grande", Arial, sans-serif !default;

--- a/docs/_sass/_page.scss
+++ b/docs/_sass/_page.scss
@@ -59,6 +59,7 @@
 
   p, li, dl {
     font-size: 1em;
+    text-align: $paragraph-align;
   }
 
   /* paragraph indents */

--- a/docs/_sass/_sidebar.scss
+++ b/docs/_sass/_sidebar.scss
@@ -47,6 +47,10 @@
 .sidebar__right {
   margin-bottom: 1em;
 
+  p, li, dl {
+    text-align: left;
+  }
+
   @include breakpoint($large) {
     position: relative;
     float: right;

--- a/docs/_sass/_variables.scss
+++ b/docs/_sass/_variables.scss
@@ -12,6 +12,9 @@ $doc-font-size              : 16 !default;
 $paragraph-indent           : false !default; // true, false (default)
 $indent-var                 : 1.3em !default;
 
+/* paragraph alignment */
+$paragraph-align            : left !default; // left (default), right, center, justify
+
 /* system typefaces */
 $serif                      : Georgia, Times, serif !default;
 $sans-serif                 : -apple-system, ".SFNSText-Regular", "San Francisco", "Roboto", "Segoe UI", "Helvetica Neue", "Lucida Grande", Arial, sans-serif !default;


### PR DESCRIPTION
This pull request comes from #883 and gives a way to choose the default text alignment without having to patch several files of the theme.