### PR TITLE
Replace `site.related_posts` with Liquid loops for improved relevancy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+### Enhancements
+
+- Replace `site.related_posts` with Liquid to display better matches based on tags instead of the most recent posts. [#554]
+
 ### Bug Fixes
 
 - Toggle close button on `mouseleave`. [#975](https://github.com/mmistakes/minimal-mistakes/issues/975)

--- a/_includes/page__related.html
+++ b/_includes/page__related.html
@@ -1,0 +1,26 @@
+{% comment %}<!-- show posts by related tags when `related: true` -->{% endcomment %}
+{% if page.related %}
+  {% assign n_posts = 0 %}
+  {% for post in site.posts %}
+    {% if post.id == page.id %}{% continue %}{% endif %}
+    {% for this_tag in page.tags %}
+        {% if post.tags contains this_tag %}
+          {% if n_posts == 0 %}
+            <div class="page__related">
+              {% if site.data.ui-text[site.locale].related_label %}
+                <h4 class="page__related-title">{{ site.data.ui-text[site.locale].related_label | default: "You May Also Enjoy" }}</h4>
+              {% endif %}
+              <div class="grid__wrapper">
+          {% endif %}
+          {% include archive-single.html type="grid" %}
+          {% assign n_posts = n_posts | plus: 1 %}
+          {% break %}
+        {% endif %}
+    {% endfor %}
+    {% if n_posts > 3 %}{% break %}{% endif %}
+  {% endfor %}
+  {% if n_posts > 0 %}
+      </div>
+    </div>
+  {% endif %}
+{% endif %}

--- a/_layouts/single.html
+++ b/_layouts/single.html
@@ -60,15 +60,5 @@ layout: default
     {% endif %}
   </article>
 
-  {% comment %}<!-- only show related on a post page when not disabled -->{% endcomment %}
-  {% if page.id and page.related and site.related_posts.size > 0 %}
-    <div class="page__related">
-      <h4 class="page__related-title">{{ site.data.ui-text[site.locale].related_label | default: "You May Also Enjoy" }}</h4>
-      <div class="grid__wrapper">
-        {% for post in site.related_posts limit:4 %}
-          {% include archive-single.html type="grid" %}
-        {% endfor %}
-      </div>
-    </div>
-  {% endif %}
+  {% include page__related.html %}
 </div>

--- a/docs/_docs/18-history.md
+++ b/docs/_docs/18-history.md
@@ -4,10 +4,14 @@ permalink: /docs/history/
 excerpt: "Change log of enhancements and bug fixes made to the theme."
 sidebar:
   nav: docs
-last_modified_at: 2017-04-27T16:01:29-04:00
+last_modified_at: 2017-04-27T16:26:51-04:00
 ---
 
 ## Unreleased
+
+### Enhancements
+
+- Replace `site.related_posts` with Liquid to display better matches based on tags instead of the most recent posts. [#554]
 
 ### Bug Fixes
 

--- a/docs/_includes/page__related.html
+++ b/docs/_includes/page__related.html
@@ -1,0 +1,26 @@
+{% comment %}<!-- show posts by related tags when `related: true` -->{% endcomment %}
+{% if page.related %}
+  {% assign n_posts = 0 %}
+  {% for post in site.posts %}
+    {% if post.id == page.id %}{% continue %}{% endif %}
+    {% for this_tag in page.tags %}
+        {% if post.tags contains this_tag %}
+          {% if n_posts == 0 %}
+            <div class="page__related">
+              {% if site.data.ui-text[site.locale].related_label %}
+                <h4 class="page__related-title">{{ site.data.ui-text[site.locale].related_label | default: "You May Also Enjoy" }}</h4>
+              {% endif %}
+              <div class="grid__wrapper">
+          {% endif %}
+          {% include archive-single.html type="grid" %}
+          {% assign n_posts = n_posts | plus: 1 %}
+          {% break %}
+        {% endif %}
+    {% endfor %}
+    {% if n_posts > 3 %}{% break %}{% endif %}
+  {% endfor %}
+  {% if n_posts > 0 %}
+      </div>
+    </div>
+  {% endif %}
+{% endif %}

--- a/docs/_layouts/single.html
+++ b/docs/_layouts/single.html
@@ -60,15 +60,5 @@ layout: default
     {% endif %}
   </article>
 
-  {% comment %}<!-- only show related on a post page when not disabled -->{% endcomment %}
-  {% if page.id and page.related and site.related_posts.size > 0 %}
-    <div class="page__related">
-      <h4 class="page__related-title">{{ site.data.ui-text[site.locale].related_label | default: "You May Also Enjoy" }}</h4>
-      <div class="grid__wrapper">
-        {% for post in site.related_posts limit:4 %}
-          {% include archive-single.html type="grid" %}
-        {% endfor %}
-      </div>
-    </div>
-  {% endif %}
+  {% include page__related.html %}
 </div>


### PR DESCRIPTION
`site.related_posts` currently outputs an array of the most recent posts for GitHub Pages hosted sites since `LSI` is disabled, as described in #554.

This PR improves on it with some Liquid code that tries to improve the relevancy of these "related posts" by comparing them with `page.tags`.

Note: there may be a slight increase in build times as all of the posts need to be looped through, which can obviously slow things down a tad if you have many posts.