### PR TITLE
add gitlab to author profile

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -90,6 +90,7 @@ author:
   facebook         :
   foursquare       :
   github           :
+  gitlab:
   google_plus      :
   keybase          :
   instagram        :

--- a/_config.yml
+++ b/_config.yml
@@ -90,7 +90,7 @@ author:
   facebook         :
   foursquare       :
   github           :
-  gitlab:
+  gitlab           :
   google_plus      :
   keybase          :
   instagram        :

--- a/_includes/author-profile.html
+++ b/_includes/author-profile.html
@@ -131,6 +131,14 @@
         </li>
       {% endif %}
 
+      {% if author.gitlab %}
+        <li>
+          <a href="https://gitlab.com/{{ author.gitlab }}" itemprop="sameAs">
+            <i class="fa fa-fw fa-gitlab" aria-hidden="true"></i> Gitlab
+          </a>
+        </li>
+      {% endif %}
+
       {% if author.stackoverflow %}
         <li>
           <a href="https://www.stackoverflow.com/users/{{ author.stackoverflow }}" itemprop="sameAs">

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -12,6 +12,9 @@
     {% if site.author.github %}
       <li><a href="http://github.com/{{ site.author.github }}"><i class="fa fa-fw fa-github" aria-hidden="true"></i> GitHub</a></li>
     {% endif %}
+    {% if site.author.gitlab %}
+      <li><a href="http://gitlab.com/{{ site.author.gitlab }}"><i class="fa fa-fw fa-gitlab" aria-hidden="true"></i> Gitlab</a></li>
+    {% endif %}
     {% if site.author.bitbucket %}
       <li><a href="http://bitbucket.org/{{ site.author.bitbucket }}"><i class="fa fa-fw fa-bitbucket" aria-hidden="true"></i> Bitbucket</a></li>
     {% endif %}


### PR DESCRIPTION
Since gitlab is widely used, add it as an option in site wide configuration and include it in the standard author profile links.