### PR TITLE
Fix warning when running jekyll serve

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -178,8 +178,8 @@ paginate_path: /page:num/
 timezone: # http://en.wikipedia.org/wiki/List_of_tz_database_time_zones
 
 
-# Plugins (previously gems:)
-plugins:
+# Plugins (previously gems, previously plugins:)
+plugins_dir:
   - jekyll-paginate
   - jekyll-sitemap
   - jekyll-gist


### PR DESCRIPTION
Hi!

I'm adapting your awesome theme for biouno.org, and while running `jekyll serve` got served (pun intended) with the following warning:

```
~/Development/java/biouno/biouno.github.io$ bundle exec jekyll serve
Configuration file: /home/kinow/Development/java/biouno/biouno.github.io/_config.yml
       Deprecation: The 'plugins' configuration option has been renamed to 'plugins_dir'. Please update your config file accordingly.
Configuration file: /home/kinow/Development/java/biouno/biouno.github.io/_config.yml
       Deprecation: The 'plugins' configuration option has been renamed to 'plugins_dir'. Please update your config file accordingly.
            Source: /home/kinow/Development/java/biouno/biouno.github.io
       Destination: /home/kinow/Development/java/biouno/biouno.github.io/_site
 Incremental build: disabled. Enable with --incremental
```

This PR renames it to plugins_dir (seems to be working fine for me at least :-) )

Thanks again!
Bruno