### PR TITLE
Header alt tags

### DIFF
--- a/_includes/page__hero.html
+++ b/_includes/page__hero.html
@@ -45,7 +45,11 @@
       {% endif %}
     </div>
   {% else %}
+    {% if page.header.image_description %}
+    <img src="{{ img_path }}" alt="{{ page.header.image_description }}" class="page__hero-image">
+    {% else %}
     <img src="{{ img_path }}" alt="{{ page.title }}" class="page__hero-image">
+    {% endif %}
   {% endif %}
   {% if page.header.caption %}
     <span class="page__hero-caption">{{ page.header.caption | markdownify | remove: "<p>" | remove: "</p>" }}</span>

--- a/docs/_docs/10-layouts.md
+++ b/docs/_docs/10-layouts.md
@@ -273,6 +273,14 @@ header:
   image: http://some-site.com/assets/images/image.jpg
 ```
 
+To provide a custom alt tag for screen readers:
+
+```yaml
+header:
+  image: /assets/images/unsplash-image-1.jpg
+  image_description: "A description of the image"
+```
+
 To include a caption or attribution for the image:
 
 ```yaml


### PR DESCRIPTION
This allows specifying a custom alt tag for a header image. Currently the theme defaults to the site title or nothing. I use a screen reader so noticed this right away, and fixed it on my site, so thought I'd push the change. Simply specify the image_description along with the image in the front matter.