### PR TITLE
Add StackExchange to author profile

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -99,6 +99,7 @@ author:
   pinterest        :
   soundcloud       :
   stackoverflow    : # "123456/username" (the last part of your profile url, e.g. http://stackoverflow.com/users/123456/username)
+  stackexchange    : # "123456/username" (the last part of your profile url, e.g. http://stackexchange.com/users/123456/username)
   steam            :
   tumblr           :
   twitter          :

--- a/_includes/author-profile.html
+++ b/_includes/author-profile.html
@@ -147,6 +147,14 @@
         </li>
       {% endif %}
 
+      {% if author.stackexchange %}
+      <li>
+        <a href="https://stackexchange.com/users/{{ author.stackexchange }}" itemprop="sameAs">
+          <i class="fa fa-fw fa-stack-exchange" aria-hidden="true"></i> Stackexchange
+        </a>
+      </li>
+      {% endif %}
+
       {% if author.lastfm %}
         <li>
           <a href="https://last.fm/user/{{ author.lastfm }}" itemprop="sameAs">


### PR DESCRIPTION
This adds the stackexchange info to author profile. I left it out in the footer since I'm not sure it should appear there.
Is there a rule for what goes into the footer? Shouldn't be most (all) of the author info appear there as well?