### PR TITLE
Include documentation on disabling animations

### DIFF
--- a/docs/_docs/16-stylesheets.md
+++ b/docs/_docs/16-stylesheets.md
@@ -45,7 +45,7 @@ To override the default [Sass](http://sass-lang.com/guide) (located in theme's
 
 1. Copy directly from the Minimal Mistakes theme gem
 
-   - Go to your local Minimal Mistakes gem installation directory (run 
+   - Go to your local Basically Basic gem installation directory (run 
      `bundle show minimal-mistakes-jekyll` to get the path to it).
    - Copy the contents of `/assets/css/main.scss` from there to 
      `<your_project>`.
@@ -161,3 +161,12 @@ And `$susy` is used for setting [the grid](http://susy.oddbird.net/) the theme u
   <img src="{{ '/assets/images/mm-susy-grid-overlay.jpg' | absolute_url }}" alt="Susy grid overlay for debugging">
   <figcaption>Susy grid debug overlay enabled.</figcaption>
 </figure>
+
+### Disabling Animations
+
+You can disable either the fade-in intro animation, element tranisition animations, or both by overriding the corresponding variables. For example if you wanted to disable all animations you could include the following lines:
+
+```scss
+$intro-transition  : none;
+$global-transition : none;
+```


### PR DESCRIPTION
Just thought I'd include a section in the docs about it since it's now officially supported and it might be a common enough use case to warrant explanation.