### PR TITLE
Improve `page` and `archive` layouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add Greek localized UI text strings. [#1159](https://github.com/mmistakes/minimal-mistakes/pull/1159)
 - Remove blank YAML Front Matter from JavaScript banner. [#1158](https://github.com/mmistakes/minimal-mistakes/issues/1158)
+- Improve `page` and `archive` layouts to visually center main content and harmonize sidebar widths and placement. [#1166](https://github.com/mmistakes/minimal-mistakes/pull/1166)
 
 ## [4.5.0](https://github.com/mmistakes/minimal-mistakes/releases/tag/4.5.0)
 

--- a/_sass/minimal-mistakes/_archive.scss
+++ b/_sass/minimal-mistakes/_archive.scss
@@ -5,14 +5,15 @@
 .archive {
   margin-bottom: 2em;
 
-  @include breakpoint($medium) {
-    width: span(12 of 12);
-  }
-
   @include breakpoint($large) {
     float: right;
-    padding-left: gutter(0.5 of 12);
-    width: span(10 of 12);
+    width: calc(100% - #{$right-sidebar-width-narrow});
+    padding-right: $right-sidebar-width-narrow;
+  }
+
+  @include breakpoint($x-large) {
+    width: calc(100% - #{$right-sidebar-width});
+    padding-right: $right-sidebar-width;
   }
 
   a {
@@ -84,17 +85,6 @@
    ========================================================================== */
 
 .list__item {
-  @include breakpoint($medium) {
-    padding-right: $right-sidebar-width-narrow;
-  }
-
-  @include breakpoint($large) {
-    padding-right: $right-sidebar-width;
-  }
-
-  @include breakpoint($x-large) {
-    padding-right: $right-sidebar-width-wide;
-  }
 
   .page__meta {
     margin: 0 0 4px;

--- a/_sass/minimal-mistakes/_navigation.scss
+++ b/_sass/minimal-mistakes/_navigation.scss
@@ -58,6 +58,7 @@
 
 .pagination {
   @include clearfix();
+  float: left;
   margin-top: 1em;
   padding-top: 1em;
   width: 100%;

--- a/_sass/minimal-mistakes/_page.scss
+++ b/_sass/minimal-mistakes/_page.scss
@@ -24,9 +24,13 @@
 
   @include breakpoint($large) {
     float: right;
-    width: span(10 of 12);
-    padding-left: gutter(0.5 of 12);
-    padding-right: gutter(2 of 12);
+    width: calc(100% - #{$right-sidebar-width-narrow});
+    padding-right: $right-sidebar-width-narrow;
+  }
+
+  @include breakpoint($x-large) {
+    width: calc(100% - #{$right-sidebar-width});
+    padding-right: $right-sidebar-width;
   }
 
   .page__inner-wrap {
@@ -409,9 +413,11 @@
 
   @include breakpoint($large) {
     float: right;
-    width: span(10 of 12);
-    padding-left: gutter(0.5 of 12);
-    padding-right: gutter(2 of 12);
+    width: calc(100% - #{$right-sidebar-width-narrow});
+  }
+
+  @include breakpoint($x-large) {
+    width: calc(100% - #{$right-sidebar-width});
   }
 
   a {

--- a/_sass/minimal-mistakes/_page.scss
+++ b/_sass/minimal-mistakes/_page.scss
@@ -43,6 +43,7 @@
     .page__content,
     .page__meta,
     .page__share {
+      position: relative;
       float: left;
       margin-left: 0;
       margin-right: 0;

--- a/_sass/minimal-mistakes/_sidebar.scss
+++ b/_sass/minimal-mistakes/_sidebar.scss
@@ -55,6 +55,7 @@
     top: 0;
     right: 0;
     width: $right-sidebar-width-narrow;
+    margin-right: -1 * $right-sidebar-width-narrow;
     padding-left: 1em;
     z-index: 10;
   }

--- a/_sass/minimal-mistakes/_sidebar.scss
+++ b/_sass/minimal-mistakes/_sidebar.scss
@@ -31,10 +31,6 @@
     }
   }
 
-  @include breakpoint($x-large) {
-    padding-right: 0;
-  }
-
   h2, h3, h4, h5, h6 {
     margin-bottom: 0;
     font-family: $sans-serif-narrow;
@@ -58,12 +54,14 @@
     position: relative;
     float: right;
     width: $right-sidebar-width-narrow;
-    margin-left: span(0.5 of 12);
+    margin-right: -1 * $right-sidebar-width-narrow;
+    padding-left: 1em;
     z-index: 10;
   }
 
   @include breakpoint($x-large) {
     width: $right-sidebar-width;
+    margin-right: -1 * $right-sidebar-width;
   }
 }
 

--- a/_sass/minimal-mistakes/_sidebar.scss
+++ b/_sass/minimal-mistakes/_sidebar.scss
@@ -51,10 +51,10 @@
   margin-bottom: 1em;
 
   @include breakpoint($large) {
-    position: relative;
-    float: right;
+    position: absolute;
+    top: 0;
+    right: 0;
     width: $right-sidebar-width-narrow;
-    margin-right: -1 * $right-sidebar-width-narrow;
     padding-left: 1em;
     z-index: 10;
   }

--- a/docs/_docs/18-history.md
+++ b/docs/_docs/18-history.md
@@ -4,7 +4,7 @@ permalink: /docs/history/
 excerpt: "Change log of enhancements and bug fixes made to the theme."
 sidebar:
   nav: docs
-last_modified_at: 2017-08-06T10:43:26-04:00
+last_modified_at: 2017-08-08T09:14:21-04:00
 ---
 
 ## Unreleased
@@ -13,6 +13,7 @@ last_modified_at: 2017-08-06T10:43:26-04:00
 
 - Add Greek localized UI text strings. [#1159](https://github.com/mmistakes/minimal-mistakes/pull/1159)
 - Remove blank YAML Front Matter from JavaScript banner. [#1158](https://github.com/mmistakes/minimal-mistakes/issues/1158)
+- Improve `page` and `archive` layouts to visually center main content and harmonize sidebar widths and placement. [#1166](https://github.com/mmistakes/minimal-mistakes/pull/1166)
 
 ## [4.5.0](https://github.com/mmistakes/minimal-mistakes/releases/tag/4.5.0)
 

--- a/docs/_posts/2012-01-03-layout-table-of-contents-bottom-post.md
+++ b/docs/_posts/2012-01-03-layout-table-of-contents-bottom-post.md
@@ -1,5 +1,5 @@
 ---
-title: "Layout: Post with Table Of Contents"
+title: "Layout: Post with Table Of Contents Included at Bottom"
 header:
   image: assets/images/unsplash-image-9.jpg
   caption: "Photo credit: [**Unsplash**](https://unsplash.com)"
@@ -7,9 +7,7 @@ tags:
   - table of contents
 ---
 
-{% include toc title="Unique Title" icon="file-text" %}
-
-Testing Kramdown auto-generated table of contents with unique title and icon assigned in the include like so:
+Testing Kramdown auto-generated table of contents included near the end of post content. If positioned correctly with CSS, it should appear in aligned (and to the right) of the main content.
 
 ```liquid
 {% raw %}{% include toc title="Unique Title" icon="file-text" %}{% endraw %}
@@ -98,3 +96,5 @@ Make any link standout more when applying the `.btn` class.
 
 **Watch out!** You can also add notices by appending `{: .notice}` to a paragraph.
 {: .notice}
+
+{% include toc title="Unique Title" icon="file-text" %}

--- a/docs/_sass/minimal-mistakes/_archive.scss
+++ b/docs/_sass/minimal-mistakes/_archive.scss
@@ -5,14 +5,15 @@
 .archive {
   margin-bottom: 2em;
 
-  @include breakpoint($medium) {
-    width: span(12 of 12);
-  }
-
   @include breakpoint($large) {
     float: right;
-    padding-left: gutter(0.5 of 12);
-    width: span(10 of 12);
+    width: calc(100% - #{$right-sidebar-width-narrow});
+    padding-right: $right-sidebar-width-narrow;
+  }
+
+  @include breakpoint($x-large) {
+    width: calc(100% - #{$right-sidebar-width});
+    padding-right: $right-sidebar-width;
   }
 
   a {
@@ -84,17 +85,6 @@
    ========================================================================== */
 
 .list__item {
-  @include breakpoint($medium) {
-    padding-right: $right-sidebar-width-narrow;
-  }
-
-  @include breakpoint($large) {
-    padding-right: $right-sidebar-width;
-  }
-
-  @include breakpoint($x-large) {
-    padding-right: $right-sidebar-width-wide;
-  }
 
   .page__meta {
     margin: 0 0 4px;

--- a/docs/_sass/minimal-mistakes/_navigation.scss
+++ b/docs/_sass/minimal-mistakes/_navigation.scss
@@ -58,6 +58,7 @@
 
 .pagination {
   @include clearfix();
+  float: left;
   margin-top: 1em;
   padding-top: 1em;
   width: 100%;

--- a/docs/_sass/minimal-mistakes/_page.scss
+++ b/docs/_sass/minimal-mistakes/_page.scss
@@ -24,9 +24,13 @@
 
   @include breakpoint($large) {
     float: right;
-    width: span(10 of 12);
-    padding-left: gutter(0.5 of 12);
-    padding-right: gutter(2 of 12);
+    width: calc(100% - #{$right-sidebar-width-narrow});
+    padding-right: $right-sidebar-width-narrow;
+  }
+
+  @include breakpoint($x-large) {
+    width: calc(100% - #{$right-sidebar-width});
+    padding-right: $right-sidebar-width;
   }
 
   .page__inner-wrap {
@@ -39,6 +43,7 @@
     .page__content,
     .page__meta,
     .page__share {
+      position: relative;
       float: left;
       margin-left: 0;
       margin-right: 0;
@@ -409,9 +414,11 @@
 
   @include breakpoint($large) {
     float: right;
-    width: span(10 of 12);
-    padding-left: gutter(0.5 of 12);
-    padding-right: gutter(2 of 12);
+    width: calc(100% - #{$right-sidebar-width-narrow});
+  }
+
+  @include breakpoint($x-large) {
+    width: calc(100% - #{$right-sidebar-width});
   }
 
   a {

--- a/docs/_sass/minimal-mistakes/_sidebar.scss
+++ b/docs/_sass/minimal-mistakes/_sidebar.scss
@@ -31,10 +31,6 @@
     }
   }
 
-  @include breakpoint($x-large) {
-    padding-right: 0;
-  }
-
   h2, h3, h4, h5, h6 {
     margin-bottom: 0;
     font-family: $sans-serif-narrow;
@@ -55,15 +51,18 @@
   margin-bottom: 1em;
 
   @include breakpoint($large) {
-    position: relative;
-    float: right;
+    position: absolute;
+    top: 0;
+    right: 0;
     width: $right-sidebar-width-narrow;
-    margin-left: span(0.5 of 12);
+    margin-right: -1 * $right-sidebar-width-narrow;
+    padding-left: 1em;
     z-index: 10;
   }
 
   @include breakpoint($x-large) {
     width: $right-sidebar-width;
+    margin-right: -1 * $right-sidebar-width;
   }
 }
 

--- a/test/_posts/2012-01-03-layout-table-of-contents-bottom-post.md
+++ b/test/_posts/2012-01-03-layout-table-of-contents-bottom-post.md
@@ -1,5 +1,5 @@
 ---
-title: "Layout: Post with Table Of Contents"
+title: "Layout: Post with Table Of Contents Included at Bottom"
 header:
   image: assets/images/unsplash-image-9.jpg
   caption: "Photo credit: [**Unsplash**](https://unsplash.com)"
@@ -7,9 +7,7 @@ tags:
   - table of contents
 ---
 
-{% include toc title="Unique Title" icon="file-text" %}
-
-Testing Kramdown auto-generated table of contents with unique title and icon assigned in the include like so:
+Testing Kramdown auto-generated table of contents included near the end of post content. If positioned correctly with CSS, it should appear in aligned (and to the right) of the main content.
 
 ```liquid
 {% raw %}{% include toc title="Unique Title" icon="file-text" %}{% endraw %}
@@ -98,3 +96,5 @@ Make any link standout more when applying the `.btn` class.
 
 **Watch out!** You can also add notices by appending `{: .notice}` to a paragraph.
 {: .notice}
+
+{% include toc title="Unique Title" icon="file-text" %}

--- a/test/_posts/2012-01-03-layout-table-of-contents-post.md
+++ b/test/_posts/2012-01-03-layout-table-of-contents-post.md
@@ -7,8 +7,6 @@ tags:
   - table of contents
 ---
 
-{% include toc title="Unique Title" icon="file-text" %}
-
 Testing Kramdown auto-generated table of contents with unique title and icon assigned in the include like so:
 
 ```liquid
@@ -98,3 +96,5 @@ Make any link standout more when applying the `.btn` class.
 
 **Watch out!** You can also add notices by appending `{: .notice}` to a paragraph.
 {: .notice}
+
+{% include toc title="Unique Title" icon="file-text" %}


### PR DESCRIPTION
Improve `page` and `archive` layout
- Center main content on page
- Harmonize sidebar columns to be equal widths

Fixes #1155