### PR TITLE
Fix discourse urls

### DIFF
--- a/_includes/comments-providers/discourse.html
+++ b/_includes/comments-providers/discourse.html
@@ -1,7 +1,7 @@
 {% if site.comments.discourse.server %}
-{% capture canonical %}{% if site.permalink contains '.html' %}{{ page.url | absolute_url }}{% else %}{{ page.url | absolute_url | remove:'index.html' | strip_slash }}{% endif %}{% endcapture %}
+{% capture canonical %}{{ page.url | replace: 'index.html','' | prepend: site.baseurl | prepend: site.url }}{% endcapture %}
 <script type="text/javascript">
-    DiscourseEmbed = { discourseUrl: '//{{ site.comments.discourse.server }}/',
+    DiscourseEmbed = { discourseUrl: '{{ site.comments.discourse.server }}/',
                        discourseEmbedUrl: '{{ canonical }}' };
    (function () {
      var d = document.createElement('script'); d.type = 'text/javascript'; d.async = true;


### PR DESCRIPTION
The current discourse embedding snippet was not working for me. I found two problems

1) the `discourseUrl` variable hardcoded  a couple of forward slashes at the beginning. The correct path should be set only with the `site.comments.discourse.server` configuration variable.

2) the canonical url assigned to `discourseEmbedUrl` was not computed correctly.

This commit attempts to fix both. 