### PR TITLE
Improve translation for minute_read.

### DIFF
--- a/_data/ui-text.yml
+++ b/_data/ui-text.yml
@@ -322,7 +322,7 @@ zh: &DEFAULT_ZH
   toc_label                  : "在本页上"
   ext_link_label             : "直接链接"
   less_than                  : "少于"
-  minute_read                : "分钟 阅读"
+  minute_read                : "分钟读完"
   share_on_label             : "分享"
   meta_label                 :
   tags_label                 : "标签:"


### PR DESCRIPTION
Although the original one can be understood, it seems strange for a native Chinese speaker. I think the updated version should be better.