### PR TITLE
Add docker environment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '2'
+
+services:
+    jekyll:
+        build: docker/jekyll
+        volumes:
+            - .:/var/www/html
+        working_dir: /var/www/html
+        ports:
+            - 4000:4000
+        command: bash -c "bundle install && bundle exec jekyll serve --host=0.0.0.0"

--- a/docker/jekyll/Dockerfile
+++ b/docker/jekyll/Dockerfile
@@ -1,0 +1,11 @@
+FROM ruby:2
+
+RUN apt-get update && \
+    apt-get install locales && \
+    locale-gen en_US.UTF-8 && \
+    localedef -i en_US -f UTF-8 en_US.UTF-8
+
+ENV LANG en_US.UTF-8
+ENV LC_ALL en_US.UTF-8
+
+RUN gem install bundler

--- a/docs/_docs/01-quick-start-guide.md
+++ b/docs/_docs/01-quick-start-guide.md
@@ -116,6 +116,22 @@ The bundled data files are:
 - [`_data/ui-text.yml`](https://github.com/mmistakes/minimal-mistakes/blob/master/_data/ui-text.yml) - UI text [documentation]({{ "/docs/ui-text/" | absolute_url }})
 - [`_data/navigation.yml`](https://github.com/mmistakes/minimal-mistakes/blob/master/_data/navigation.yml) - navigation [documentation]({{ "/docs/navigation/" | absolute_url }})
 
+#### Docker
+
+There is also a Docker environment. This way, you don't need to install Ruby environment.
+
+You need Docker and docker-compose.
+
+Once you cloned a fresh install of Minimal Mistakes, run:
+
+``` bash
+docker-compose up
+```
+
+Wait for images download and mount, then you'll be able to access to:
+
+http://0.0.0.0:4000
+
 ### Starting from `jekyll new`
 
 Scaffolding out a site with the `jekyll new` command requires you to modify a few files that it creates.


### PR DESCRIPTION
I'm using this Docker environment to work with this Jekyll theme.

I'm sharing it in this PR.

You should be able to test it by fetching this branch, and by running `docker-compose up`.

Then you should access to your fresh install at http://0.0.0.0:4000