### PR TITLE
Enable Liquid and Front Matter strict mode

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -245,3 +245,8 @@ defaults:
       comments: # true
       share: true
       related: true
+
+# Jekyll compilation
+strict_front_matter: true
+liquid:
+ error_mode: strict


### PR DESCRIPTION
I am a great believer in strict compilation and "warnings as errors" in basically anything that compiles.