### PR TITLE
Rename `gems` key to `plugins`

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -178,8 +178,8 @@ paginate_path: /page:num/
 timezone: # http://en.wikipedia.org/wiki/List_of_tz_database_time_zones
 
 
-# Plugins
-gems:
+# Plugins (previously gems:)
+plugins:
   - jekyll-paginate
   - jekyll-sitemap
   - jekyll-gist


### PR DESCRIPTION
`gems` key in `_config.yml` was deprecated in Jekyll 3.5 and changed to `plugins`.

ref: https://github.com/jekyll/jekyll/pull/5130