### PR TITLE
Add naver-site-verification to SEO

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -54,6 +54,7 @@ google_site_verification :
 bing_site_verification   :
 alexa_site_verification  :
 yandex_site_verification :
+naver-site-verification :
 
 # Social Sharing
 twitter:

--- a/_includes/seo.html
+++ b/_includes/seo.html
@@ -144,4 +144,7 @@
 {% if site.yandex_site_verification %}
   <meta name="yandex-verification" content="{{ site.yandex_site_verification }}">
 {% endif %}
+{% if site.naver-site-verification %}
+<meta name="naver-site-verification" content="{{ site.naver-site-verification }}">
+{% endif %}
 <!-- end SEO -->

--- a/_includes/seo.html
+++ b/_includes/seo.html
@@ -145,6 +145,6 @@
   <meta name="yandex-verification" content="{{ site.yandex_site_verification }}">
 {% endif %}
 {% if site.naver-site-verification %}
-<meta name="naver-site-verification" content="{{ site.naver-site-verification }}">
+  <meta name="naver-site-verification" content="{{ site.naver-site-verification }}">
 {% endif %}
 <!-- end SEO -->


### PR DESCRIPTION
I Added a new search engine [Naver](https://naver.com/) to SEO.
Working example is [my github pages](https://lovemewithoutall.github.io/).