### PR TITLE
Fix system font rendering in Chrome on macOS/OS X

### DIFF
--- a/_sass/minimal-mistakes/_variables.scss
+++ b/_sass/minimal-mistakes/_variables.scss
@@ -14,7 +14,7 @@ $indent-var                   : 1.3em !default;
 
 /* system typefaces */
 $serif                        : Georgia, Times, serif !default;
-$sans-serif                   : -apple-system, ".SFNSText-Regular", "San Francisco", "Roboto", "Segoe UI", "Helvetica Neue", "Lucida Grande", Arial, sans-serif !default;
+$sans-serif                   : -apple-system, BlinkMacSystemFont, "Roboto", "Segoe UI", "Helvetica Neue", "Lucida Grande", Arial, sans-serif !default;
 $monospace                    : Monaco, Consolas, "Lucida Console", monospace !default;
 
 /* sans serif typefaces */


### PR DESCRIPTION
Use `BlinkMacSystemFont` instead of private font name.

Closes #1289