### PR TITLE
Fix lunar-en.js layout (Uncaught SyntaxError)

### DIFF
--- a/assets/js/lunr-en.js
+++ b/assets/js/lunr-en.js
@@ -1,4 +1,5 @@
 ---
+layout: null
 ---
 
 var idx = lunr(function () {


### PR DESCRIPTION
Without layout set to null a HTML template will be rendered around the JavaScript, causing an error while loading the file in the browser.

```
lunr-en.js:1 Uncaught SyntaxError: Unexpected token <
```