### PR TITLE
Feature: Adding linkback functionality Author avatar & Name

### DIFF
--- a/_includes/author-profile.html
+++ b/_includes/author-profile.html
@@ -10,29 +10,27 @@
     <div class="author__avatar">
       {% if author.avatar contains "://" %}
         {% assign author_src = author.avatar %}
-        {% assign author_class = "" %}
       {% else %}
         {% assign author_src = author.avatar | absolute_url %}
-        {% assign author_class = "author__avatar" %}
       {% endif %}
 
-      {% if author.linkback %}
-        {% if author.linkback contains "://" %}
-          {% assign author_link = author.linkback %}
+      {% if author.home %}
+        {% if author.home contains "://" %}
+          {% assign author_link = author.home %}
         {% else %}
-          {% assign author_link = author.linkback | absolute_url %}
+          {% assign author_link = author.home | absolute_url %}
         {% endif %}
         <a href="{{ author_link }}">
-          <img src="{{ author_src }}" class="{{ author_class }}" alt="{{ author.name }}" itemprop="image">
+          <img src="{{ author_src }}" alt="{{ author.name }}" itemprop="image">
         </a>
       {% else %}
-        <img src="{{ author_src }}" class="{{ author_class }}" alt="{{ author.name }}" itemprop="image">
+        <img src="{{ author_src }}" alt="{{ author.name }}" itemprop="image">
       {% endif %}
     </div>
   {% endif %}
 
   <div class="author__content">
-    {% if author.linkback %}
+    {% if author.home %}
       <a href="{{ author_link }}"><h3 class="author__name" itemprop="name">{{ author.name }}</h3></a>
     {% else %}
       <h3 class="author__name" itemprop="name">{{ author.name }}</h3>

--- a/_includes/author-profile.html
+++ b/_includes/author-profile.html
@@ -9,15 +9,34 @@
   {% if author.avatar %}
     <div class="author__avatar">
       {% if author.avatar contains "://" %}
-        <img src="{{ author.avatar }}" alt="{{ author.name }}" itemprop="image">
+        {% assign author_src = author.avatar %}
+        {% assign author_class = "" %}
       {% else %}
-        <img src="{{ author.avatar | absolute_url }}" class="author__avatar" alt="{{ author.name }}" itemprop="image">
+        {% assign author_src = author.avatar | absolute_url %}
+        {% assign author_class = "author__avatar" %}
+      {% endif %}
+
+      {% if author.linkback %}
+        {% if author.linkback contains "://" %}
+          {% assign author_link = author.linkback %}
+        {% else %}
+          {% assign author_link = author.linkback | absolute_url %}
+        {% endif %}
+        <a href="{{ author_link }}">
+          <img src="{{ author_src }}" class="{{ author_class }}" alt="{{ author.name }}" itemprop="image">
+        </a>
+      {% else %}
+        <img src="{{ author_src }}" class="{{ author_class }}" alt="{{ author.name }}" itemprop="image">
       {% endif %}
     </div>
   {% endif %}
 
   <div class="author__content">
-    <h3 class="author__name" itemprop="name">{{ author.name }}</h3>
+    {% if author.linkback %}
+      <a href="{{ author_link }}"><h3 class="author__name" itemprop="name">{{ author.name }}</h3></a>
+    {% else %}
+      <h3 class="author__name" itemprop="name">{{ author.name }}</h3>
+    {% endif %}
     {% if author.bio %}
       <p class="author__bio" itemprop="description">
         {{ author.bio }}

--- a/_sass/minimal-mistakes/_sidebar.scss
+++ b/_sass/minimal-mistakes/_sidebar.scss
@@ -128,6 +128,11 @@
     padding-left: 0;
     padding-right: 0;
   }
+
+  a {
+    color: inherit;
+    text-decoration: none;
+  }
 }
 
 .author__name {

--- a/docs/_docs/05-configuration.md
+++ b/docs/_docs/05-configuration.md
@@ -636,6 +636,7 @@ author:
   bio    : "My awesome biography constrained to a sentence or two goes here."
   email  : # optional
   uri    : "http://your-site.com"
+  home   : # null (default), "absolute or relative url to link to author home"
 ```
 
 Social media links are all optional, include the ones you want visible. In most cases you just need to add the username. If you're unsure double check `_includes/author-profile.html` to see how the URL is constructed.


### PR DESCRIPTION
This pull request is an attempt at addressing #1331.  This is the simplest/cleanest way that I can think to add this functionality.  If this is too messy, I completely understand and we can close this and I can simply do it locally, but again, I always like to keep customization as minimal as possible to more easily take advantage of future updates.

At any rate, I think this solution does solve the concern noted in #1331 around easily turning it on/off and allowing it for one, some, or many authors depending on the site's structure.

Basically, the code will check for an `author.linkback` yml key and if it is set, then it will add the link around a given author's avatar and name.  If it is not set, then the link will not be generated.

If this is something you'd consider adding in, I can certainly update the docs where applicable, but wanted to see if you'd even consider this before doing that?
