### PR TITLE
Feature: Social Sharing Extensibility Include

### DIFF
--- a/_includes/social-share-custom-links.html
+++ b/_includes/social-share-custom-links.html
@@ -1,0 +1,3 @@
+<!--
+	<a href="http://link-to-whatever-social-network.com?url={{ page.url | absolute_url | url_encode }}" class="btn btn--social-network" onclick="window.open(this.href, 'window', 'left=20,top=20,width=500,height=500,toolbar=1,resizable=0'); return false;" title="{{ site.data.ui-text[site.locale].share_on_label | default: 'Share on' }} Your Custom Social Network"><i class="fa fa-fw fa-social-network" aria-hidden="true"></i><span> Your Custom Social Network</span></a>
+-->

--- a/_includes/social-share.html
+++ b/_includes/social-share.html
@@ -10,4 +10,7 @@
   <a href="https://plus.google.com/share?url={{ page.url | absolute_url | url_encode }}" class="btn btn--google-plus" onclick="window.open(this.href, 'window', 'left=20,top=20,width=500,height=500,toolbar=1,resizable=0'); return false;" title="{{ site.data.ui-text[site.locale].share_on_label | default: 'Share on' }} Google Plus"><i class="fa fa-fw fa-google-plus" aria-hidden="true"></i><span> Google+</span></a>
 
   <a href="https://www.linkedin.com/shareArticle?mini=true&url={{ page.url | absolute_url | url_encode }}" class="btn btn--linkedin" onclick="window.open(this.href, 'window', 'left=20,top=20,width=500,height=500,toolbar=1,resizable=0'); return false;" title="{{ site.data.ui-text[site.locale].share_on_label | default: 'Share on' }} LinkedIn"><i class="fa fa-fw fa-linkedin" aria-hidden="true"></i><span> LinkedIn</span></a>
+
+  {% include social-share-custom-links.html %}
+
 </section>

--- a/docs/_docs/10-layouts.md
+++ b/docs/_docs/10-layouts.md
@@ -641,13 +641,19 @@ The `single` layout has an option to enable social links at the bottom of posts 
 
 To enable these links add `share: true` to a post or page's YAML Front Matter or use a [default](https://jekyllrb.com/docs/configuration/#front-matter-defaults) in your `_config.yml` to apply more globally.
 
-If you'd like to add, remove, or change the order of these default links you can do so by editing [`_includes/social-share.html`](https://github.com/mmistakes/minimal-mistakes/blob/master/_includes/social-share.html).
+If you'd like to remove or change the order of these default links you can do so by editing [`_includes/social-share.html`](https://github.com/mmistakes/minimal-mistakes/blob/master/_includes/social-share.html).
 
 Let's say you wanted to replace the Google+ button with a Reddit one. Simply replace the HTML with the following:
 
 ```html
 {% raw %}<a href="https://www.reddit.com/submit?url={{ page.url | absolute_url }}&title={{ page.title }}" class="btn" title="{{ site.data.ui-text[site.locale].share_on_label }} Reddit"><i class="fa fa-fw fa-reddit" aria-hidden="true"></i><span> Reddit</span></a>{% endraw %}
 ```
+
+If you'd like to add more links you can either edit [`_includes/social-share.html`](https://github.com/mmistakes/minimal-mistakes/blob/master/_includes/social-share.html) directly or you can add additional links or customization to [`_includes/social-share-custom-links.html`](https://github.com/mmistakes/minimal-mistakes/blob/master/_includes/social-hare-custom-links.html) and add your link there.
+
+**Please note:** Links added here will appear after the ones in [`_includes/social-share.html`](https://github.com/mmistakes/minimal-mistakes/blob/master/_includes/social-share.html). If you'd like to change the order of appearance you'll need to edit that file directly.
+{: .notice--info}
+
 
 The important parts to change are:
 


### PR DESCRIPTION
Similar to commit 2215ee5 that added easy customization extensibility for author links in the sidebar, this pull request does the same thing but for the Social Sharing section at the bottom of posts.

My specific use case was to add a "Discuss on" section underneath the theme's already defined "Social Sharing" section where users could click the link to discuss blog posts on specific social media sites.  So, it turned out looking like:

<kbd>
<img width="610" alt="screen shot 2017-12-06 at 9 20 10 pm" src="https://user-images.githubusercontent.com/2396774/33695457-78fdfcf2-dacb-11e7-8b39-75121098be35.png">
</kbd>

###

I directly edited the `_includes/social-share.html` file in order to accomplish this, however, I thought it might be helpful to have something similar to the existing `includes/author-profile-custom-links.html` but for this section.  I think the added benefit here would give some additional flexibility for extending other social media sharing buttons here, even though it's clearly not difficult to edit that file either.  Anyways, wanted to share this if you thought useful to add in...

