### PR TITLE
Make excerpts optional in header overlay

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -252,3 +252,5 @@ defaults:
       comments: # true
       share: true
       related: true
+      header:
+        show_overlay_excerpt: true

--- a/_includes/page__hero.html
+++ b/_includes/page__hero.html
@@ -42,7 +42,7 @@
           {{ page.title | default: site.title | markdownify | remove: "<p>" | remove: "</p>" }}
         {% endif %}
       </h1>
-      {% if page.excerpt %}
+      {% if page.header.show_overlay_excerpt and page.excerpt %}
         <p class="page__lead">{{ page.excerpt | markdownify | remove: "<p>" | remove: "</p>" }}</p>
       {% endif %}
       {% if site.read_time and page.read_time %}


### PR DESCRIPTION
Some posts and some header images don't lend themselves well to
displaying the excerpt in the overlay. Make this optional by
introducting a new boolean variable:

page.header.show_overlay_excerpt

Set it to default to true so existing users are unaffected.

This can be enabled globally for a site by changing the default to false
in the local _config.yml, or per page by specifying the value in front
matter.

Signed-off-by: Darren Hart <darren@dvhart.com>