### PR TITLE
Document show_overlay_excerpt variable

### DIFF
--- a/_docs/09-layouts.md
+++ b/_docs/09-layouts.md
@@ -250,13 +250,14 @@ header:
 
 To overlay text on top of a header image you have a few more options:
 
-| Name               | Description | Default |
-| ----               | ----------- | ------- |
-| **overlay_image**  | Header image you'd like to overlay. Same rules as `header.image` from above. | |
-| **overlay_filter** | Color/opacity to overlay on top of the header image eg: `0.5` or `rgba(255, 0, 0, 0.5)`. |
-| **excerpt**        | Auto-generated page excerpt is added to the overlay text or can be overridden. | |
-| **cta_label**      | Call to action button text label. | `more_label` in UI Text data file |
-| **cta_url**        | Call to action button URL. | |
+| Name                     | Description | Default |
+| ----                     | ----------- | ------- |
+| **overlay_image**        | Header image you'd like to overlay. Same rules as `header.image` from above. | |
+| **overlay_filter**       | Color/opacity to overlay on top of the header image eg: `0.5` or `rgba(255, 0, 0, 0.5)`. |
+| **excerpt**              | Auto-generated page excerpt is added to the overlay text or can be overridden. | |
+| **show_overlay_excerpt** | Display excerpt in the overlay test | true |
+| **cta_label**            | Call to action button text label. | `more_label` in UI Text data file |
+| **cta_url**              | Call to action button URL. | |
 
 With this YAML Front Matter:
 


### PR DESCRIPTION
Add show_overlay_excerpt variable to the Header Overlay field
documentation table.

Signed-off-by: Darren Hart <darren@dvhart.com>