### PR TITLE
Introduce show_overlay_excerpt and document

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -252,3 +252,5 @@ defaults:
       comments: # true
       share: true
       related: true
+      header:
+        show_overlay_excerpt: true

--- a/_includes/page__hero.html
+++ b/_includes/page__hero.html
@@ -42,7 +42,7 @@
           {{ page.title | default: site.title | markdownify | remove: "<p>" | remove: "</p>" }}
         {% endif %}
       </h1>
-      {% if page.excerpt %}
+      {% if page.header.show_overlay_excerpt and page.excerpt %}
         <p class="page__lead">{{ page.excerpt | markdownify | remove: "<p>" | remove: "</p>" }}</p>
       {% endif %}
       {% if site.read_time and page.read_time %}

--- a/docs/_docs/10-layouts.md
+++ b/docs/_docs/10-layouts.md
@@ -339,13 +339,14 @@ header:
 
 To overlay text on top of a header image you have a few more options:
 
-| Name               | Description | Default |
-| ----               | ----------- | ------- |
-| **overlay_image**  | Header image you'd like to overlay. Same rules as `header.image` from above. | |
-| **overlay_filter** | Color/opacity to overlay on top of the header image eg: `0.5` or `rgba(255, 0, 0, 0.5)`. |
-| **excerpt**        | Auto-generated page excerpt is added to the overlay text or can be overridden. | |
-| **cta_label**      | Call to action button text label. | `more_label` in UI Text data file |
-| **cta_url**        | Call to action button URL. | |
+| Name                     | Description | Default |
+| ----                     | ----------- | ------- |
+| **overlay_image**        | Header image you'd like to overlay. Same rules as `header.image` from above. | |
+| **overlay_filter**       | Color/opacity to overlay on top of the header image eg: `0.5` or `rgba(255, 0, 0, 0.5)`. |
+| **show_overlay_excerpt** | Display excerpt in the overlay test | true |
+| **excerpt**              | Auto-generated page excerpt is added to the overlay text or can be overridden. | |
+| **cta_label**            | Call to action button text label. | `more_label` in UI Text data file |
+| **cta_url**              | Call to action button URL. | |
 
 With this YAML Front Matter:
 


### PR DESCRIPTION
These two patches introduce a new feature allowing the per-page override of whether or not to display the excerpt in the overlay text, and document its usage.