### PR TITLE
Add 'hide_site_title' flag to pages

### DIFF
--- a/_includes/seo.html
+++ b/_includes/seo.html
@@ -5,7 +5,11 @@
 {%- assign seo_url = seo_url | default: site.github.url -%}
 
 {%- if page.title -%}
-  {%- assign seo_title = page.title | append: " " | append: site.title_separator | append: " " | append: site.title -%}
+  {%- if page.hide_site_title -%}
+    {%- assign seo_title = page.title -%}
+  {%- else -%}
+    {%- assign seo_title = page.title | append: " " | append: site.title_separator | append: " " | append: site.title -%}
+  {%- endif -%}
 {%- endif -%}
 
 {%- if seo_title -%}


### PR DESCRIPTION
Hi there!

There are some pages that I don't want to have a title suffix, ie.: instead of `My Page - My Site`, I'd like to only have `My Page`.
Does it make sense? Please let me know if there's a better/easier way to do it :)

Cheers.