### PR TITLE
Fix jsonify name in seo.html application/ld+json script

### DIFF
--- a/_includes/seo.html
+++ b/_includes/seo.html
@@ -137,7 +137,7 @@
     {
       "@context" : "http://schema.org",
       "@type" : "{% if site.social.type %}{{ site.social.type }}{% else %}Person{% endif %}",
-      "name" : "{{ site.social.name | default: site.name }}",
+      "name" : {{ site.social.name | default: site.name | jsonify }},
       "url" : {{ seo_url | jsonify }},
       "sameAs" : {{ site.social.links | jsonify }}
     }


### PR DESCRIPTION
When the name includes &quot; then the resulting schema is invalid. This is a fix.