### PR TITLE
fix a typo in 04-upgrading.md

### DIFF
--- a/docs/_docs/04-upgrading.md
+++ b/docs/_docs/04-upgrading.md
@@ -8,7 +8,7 @@ toc: true
 
 If you're using the [Ruby Gem]({{ "/docs/quick-start-guide/#ruby-gem-method" | absolute_url }}) or [remote theme]({{ "/docs/quick-start-guide/#github-pages-method" | absolute_url }}) versions of Minimal Mistakes, upgrading is fairly painless.
 
-To check which version you are currently using, view the source of your built site and you should something similar to:
+To check which version you are currently using, view the source of your built site and you should see something similar to:
 
 ```
 <!--


### PR DESCRIPTION
It's a trivial typo that I found when reading your documents.

In "minimal-mistakes/docs/_docs/04-upgrading.md", it seems a verb is missing in "To check which version you are currently using, view the source of your built site and you should something similar to:
".

Thank you for the amazing Jekll theme. 👍 
