### PR TITLE
polish language code fix

### DIFF
--- a/_data/ui-text.yml
+++ b/_data/ui-text.yml
@@ -931,7 +931,7 @@ pl: &DEFAULT_PL
   comment_success_msg        : "Dziękuję za Twój komentarz! Zostanie dodany po akceptacji."
   comment_error_msg          : "Niestety wystąpił błąd. Proszę upewnij się, że wszystkie wymagane pola zostały wypełnione i spróbuj ponownie."
   loading_label              : "Trwa ładowanie strony..."
-da-PL:
+pl-PL:
   <<: *DEFAULT_PL
 
 # Japanese


### PR DESCRIPTION
Hi Michael,

I've fixed a small typo in ui-text.yml regarding language code for Polish language. Fix is trivial, so nothing special to explain, just da-PL changed to pl-PL

Thank you and Best Regards

Artur