### PR TITLE
Add support for Google Analytics with global site tag (gtag.js)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -83,7 +83,7 @@ social:
 
 # Analytics
 analytics:
-  provider               : false # false (default), "google", "google-universal", "custom"
+  provider               : false # false (default), "google", "google-universal", "google-gtag", "custom"
   google:
     tracking_id          :
 

--- a/_includes/analytics-providers/google-gtag.html
+++ b/_includes/analytics-providers/google-gtag.html
@@ -1,0 +1,9 @@
+<!-- Global site tag (gtag.js) - Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id={{ site.analytics.google.tracking_id }}"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', '{{ site.analytics.google.tracking_id }}');
+</script>

--- a/_includes/analytics.html
+++ b/_includes/analytics.html
@@ -5,6 +5,8 @@
   {% include /analytics-providers/google.html %}
 {% when "google-universal" %}
   {% include /analytics-providers/google-universal.html %}
+{% when "google-gtag" %}
+  {% include /analytics-providers/google-gtag.html %}
 {% when "custom" %}
   {% include /analytics-providers/custom.html %}
 {% endcase %}

--- a/docs/_docs/05-configuration.md
+++ b/docs/_docs/05-configuration.md
@@ -679,13 +679,14 @@ Analytics is disabled by default. To enable globally select one of the following
 | -------------------- | --------------------------------------------------------------- |
 | **google**           | [Google Standard Analytics](https://www.google.com/analytics/)  |
 | **google-universal** | [Google Universal Analytics](https://www.google.com/analytics/) |
+| **google-gtag**      | [Google Analytics Global Site Tag)](https://www.google.com/analytics/) |
 | **custom**           | Other analytics providers                                       |
 
 For Google Analytics add your Tracking Code:
 
 ```yaml
 analytics:
-  provider: "google-universal"
+  provider: "google-gtag"
   google:
     tracking_id: "UA-1234567-8"
 ```


### PR DESCRIPTION
For documentation see https://developers.google.com/analytics/devguides/collection/gtagjs/
and https://support.google.com/analytics/answer/7538414.