### PR TITLE
Fix typos

### DIFF
--- a/_includes/read-time.html
+++ b/_includes/read-time.html
@@ -2,13 +2,13 @@
 
 {% if post.read_time %}
   {% assign words = post.content | strip_html | number_of_words %}
-{% elsif page.read_time %}
+{% elseif page.read_time %}
   {% assign words = page.content | strip_html | number_of_words %}
 {% endif %}
 
 {% if words < words_per_minute %}
   {{ site.data.ui-text[site.locale].less_than | default: "less than" }} 1 {{ site.data.ui-text[site.locale].minute_read | default: "minute read" }}
-{% elsif words == words_per_minute %}
+{% elseif words == words_per_minute %}
   1 {{ site.data.ui-text[site.locale].minute_read | default: "minute read" }}
 {% else %}
   {{ words | divided_by:words_per_minute }} {{ site.data.ui-text[site.locale].minute_read | default: "minute read" }}


### PR DESCRIPTION
I was looking at the `read-time.html` file to see how it worked and noticed that it said `elsif` rather than `elseif`.