### PR TITLE
Adding a Mailchimp Powered Pop-up working 'on-click' (non-intrusive)

### DIFF
--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -14,6 +14,7 @@
               <a href="{{ domain }}{{ link.url }}" {% if link.description %}title="{{ link.description }}"{% endif %}>{{ link.title }}</a>
             </li>
           {% endfor %}
+          <a href="#" id="open-popup" onclick ="showMailingPopUp(); return false;">Join Newsletter</a>
         </ul>
         {% if site.search == true %}
         <button class="search__toggle" type="button">

--- a/_includes/newsletter.html
+++ b/_includes/newsletter.html
@@ -1,0 +1,18 @@
+<script type="text/javascript" src="//downloads.mailchimp.com/js/signup-forms/popup/embed.js" data-dojo-config="usePlainJson: true, isDebug: false">
+</script>
+<script>
+function showMailingPopUp() {
+  require(
+    ["mojo/signup-forms/Loader"],
+    function(L) {
+      L.start({"baseUrl":"yourbaseurl","uuid":"youruuid","lid":"yourlid"})
+    }
+  );
+
+  document.cookie = "MCPopupClosed=;path=/;expires=Thu, 01 Jan 1970 00:00:00 UTC;";
+  document.cookie = "MCPopupSubscribed=;path=/;expires=Thu, 01 Jan 1970 00:00:00 UTC;";
+}
+
+document.getElementById("open-popup").onclick = function() {showMailingPopUp()};
+
+</script>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -37,6 +37,7 @@
     </div>
 
     {% include scripts.html %}
+    {% include newsletter.html %}
 
   </body>
 </html>


### PR DESCRIPTION
Script to make Mailchimp pop-up work 'on click' (Mailchimp's provided code pops up automatically in your screen - not a fan-). 

1) You should replace your own baseURL in the script (from pop-up code Mailchimp provides you)
2) You should replace your own uuid in the script (from pop-up code Mailchimp provides you)
3) You should replace your own lid in the script (from pop-up code Mailchimp provides you)