### PR TITLE
Add GitLab social icon brand color

### DIFF
--- a/_sass/minimal-mistakes/_utilities.scss
+++ b/_sass/minimal-mistakes/_utilities.scss
@@ -224,6 +224,10 @@ body:hover .visually-hidden button {
     color: $github-color;
   }
 
+  .fa-gitlab {
+    color: $gitlab-color;
+  }
+
   .fa-google-plus,
   .fa-google-plus-square,
   .fa-google-plus-g {

--- a/_sass/minimal-mistakes/_variables.scss
+++ b/_sass/minimal-mistakes/_variables.scss
@@ -82,6 +82,7 @@ $facebook-color: #3b5998 !default;
 $flickr-color: #ff0084 !default;
 $foursquare-color: #0072b1 !default;
 $github-color: #171516 !default;
+$gitlab-color: #e24329 !default;
 $google-plus-color: #dd4b39 !default;
 $instagram-color: #517fa4 !default;
 $lastfm-color: #d51007 !default;


### PR DESCRIPTION
Resolves #1653

* Of the four official brand colors documented on [brandcolors.net](https://brandcolors.net/b/gitlab) (fca326, fc6d26, e24329, & 554488), selected e24329.
* Also, there is currently only one [GitLab FontAwesome icon](https://fontawesome.com/icons?d=gallery&q=gitlab&s=brands&m=free).