### PR TITLE
allow external link _target

### DIFF
--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -11,7 +11,7 @@
               {% assign domain = site.url | append: site.baseurl %}
             {% endif %}
             <li class="masthead__menu-item">
-              <a href="{{ domain }}{{ link.url }}" {% if link.description %}title="{{ link.description }}"{% endif %}>{{ link.title }}</a>
+              <a href="{{ domain }}{{ link.url }}" {% if link.description %}title="{{ link.description }}"{% endif %} {% if link.target %}target="{{ link.target }}"{% endif %}>{{ link.title }}</a>
             </li>
           {% endfor %}
         </ul>

--- a/docs/_docs/07-navigation.md
+++ b/docs/_docs/07-navigation.md
@@ -26,15 +26,16 @@ main:
     url: /page-archive/
   - title: "Collections"
     url: /collection-archive/
-  - title: "External Link"
+  - title: "External Link ↗"
     url: https://google.com
+    target: "_blank"
 ```
 
 Which will give you a responsive masthead similar to this:
 
 ![priority plus masthead animation]({{ "/assets/images/mm-priority-plus-masthead.gif" | relative_url }})
 
-Optionally, you can add a `description` key per title in the `main` key. This `description` will show up like a tooltip, when the user hovers over the link on a desktop browser.
+Optionally, you can add a `description` key per title in the `main` key. This `description` will show up like a tooltip, when the user hovers over the link on a desktop browser.  You can also optionally specify a `target`, allowing you to open links in new tabs/windows.
 
 **ProTip:** Put the most important links first so they're always visible and not hidden behind the **menu toggle**.
 {: .notice--info}


### PR DESCRIPTION
I like to have external links have the option to open in a new tab.  This allows users to specify that.