### PR TITLE
Add minimum_tag_count param to _layouts/tags.html

### DIFF
--- a/_layouts/tags.html
+++ b/_layouts/tags.html
@@ -1,8 +1,11 @@
 ---
 layout: archive
+minimum_tag_count: 1
 ---
 
 {{ content }}
+
+{% assign tags_min = page.minimum_tag_count %}
 
 <ul class="taxonomy__index">
   {% assign tags_max = 0 %}
@@ -11,7 +14,7 @@ layout: archive
       {% assign tags_max = tag[1].size %}
     {% endif %}
   {% endfor %}
-  {% for i in (1..tags_max) reversed %}
+  {% for i in (tags_min..tags_max) reversed %}
     {% for tag in site.tags %}
       {% if tag[1].size == i %}
         <li>
@@ -31,7 +34,7 @@ layout: archive
   {% endif %}
 {% endfor %}
 
-{% for i in (1..tags_max) reversed %}
+{% for i in (tags_min..tags_max) reversed %}
   {% for tag in site.tags %}
     {% if tag[1].size == i %}
       <section id="{{ tag[0] | slugify | downcase }}" class="taxonomy__section">


### PR DESCRIPTION
Adds a `page` parameter `minimum_tag_count`. Any tags with *fewer* than `minimum_tag_count` (no bounds checking, less than 1 is like 1) will be omitted from the tags page.

My tags (currently) outnumber the posts, and I felt it was really noisy going to the Tags page and seeing a long list of tags with only one post. So, adding this parameter allows adding `minimum_tag_count: 2` to the front matter of the Tags page, and it hides any tag with just 1 post.

It *is* semi-broken because the tag on the post links to the Tags page, which then doesn't have that tag.

Thanks for all the awesome work on this theme, and I won't mind if you don't think this is right for the project (or if there's a better way to achieve this). I had the idea, tried it out, and thought it might be worth sharing. I don't know if this is useful enough to merge, or if I'm in the minority wanting this feature.