### PR TITLE
Changes to list of files that can be deleted

### DIFF
--- a/docs/_docs/01-quick-start-guide.md
+++ b/docs/_docs/01-quick-start-guide.md
@@ -91,7 +91,6 @@ If you forked or downloaded the `minimal-mistakes-jekyll` repo you can safely re
 - `/docs`
 - `/test`
 - `CHANGELOG.md`
-- `minimal-mistakes-jekyll.gemspec`
 - `README.md`
 - `screenshot-layouts.png`
 - `screenshot.png`


### PR DESCRIPTION
Removing the minimal-mistakes-jekyll.gemspec file breaks the ability to run locally using "bundle exec jekyll serve".