### PR TITLE
trival_fix_of_doc

### DIFF
--- a/docs/_docs/01-quick-start-guide.md
+++ b/docs/_docs/01-quick-start-guide.md
@@ -92,6 +92,7 @@ If you forked or downloaded the `minimal-mistakes-jekyll` repo you can safely re
 - `/test`
 - `CHANGELOG.md`
 - `minimal-mistakes-jekyll.gemspec`
+- `Gemfile`
 - `README.md`
 - `screenshot-layouts.png`
 - `screenshot.png`


### PR DESCRIPTION
if `minimal-mistakes-jekyll.gemspec` is deleted, `Gemfile` should be deleted too,
otherwise there will be an error when you run  `jekyll serve` 
such as "There was an error parsing `Gemfile`: There are no gemspecs at /tmp/minimal-mistakes-master. Bundler cannot continue."