### PR TITLE
remove the slash at the beginning of the 'path' in staticman.yml's example

### DIFF
--- a/docs/_docs/05-configuration.md
+++ b/docs/_docs/05-configuration.md
@@ -376,7 +376,7 @@ comments:
       options:
         format       : "iso8601"
   moderation         : true
-  path               : "/_data/comments/{options.slug}" (default)
+  path               : "_data/comments/{options.slug}"
   requiredFields     : ["name", "email", "message"]
   transforms:
     email            : md5


### PR DESCRIPTION
If the 'path' begin with a slash, you will receive the following error message when you post a comment
```
{
    "success":false,
    "rawError":
    {
        "code":422,
        "status":"Unprocessable Entity",
        "message":"{\"message\":\"path cannot start with a slash\",\"errors\":[{\"resource\":\"Commit\",\"field\":\"path\",\"code\":\"invalid\"}],\"documentation_url\":\"https://developer.github.com/v3/repos/contents/#update-a-file\"}"
    },
    "errorCode":"GITHUB_WRITING_FILE"
}
```
