### PR TITLE
Add `{{ content }}` to `home` layout

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -2,6 +2,8 @@
 layout: archive
 ---
 
+{{ content }}
+
 <h3 class="archive__subtitle">{{ site.data.ui-text[site.locale].recent_posts | default: "Recent Posts" }}</h3>
 
 {% for post in paginator.posts %}

--- a/test/index.html
+++ b/test/index.html
@@ -2,3 +2,4 @@
 layout: home
 author_profile: true
 ---
+This text should appear above the recent posts.


### PR DESCRIPTION
Allow the author to add content which will appear above the list of
recent posts. This also allows the `home` layout to be extended.

Add text to `test/index.html` to indicate that the content appears in
the correct spot.

This PR will resolve #1773.