### PR TITLE
Remove recommendation to add reCaptcha to staticman.yml

### DIFF
--- a/docs/_docs/05-configuration.md
+++ b/docs/_docs/05-configuration.md
@@ -441,7 +441,7 @@ To skip this moderation step simply set `moderation: false`.
 To enable Google's reCAPTCHA to aid in spam detection you'll need to:
 
 1. Apply for [reCAPTCHA API](https://www.google.com/recaptcha) keys and register your site using the reCAPTCHA V2 type.
-2. Add your site and secret keys to `staticman.yml` and `_config.yml`. Be sure to properly encrypt your secret key using [Staticman's encrypt endpoint](https://staticman.net/docs/encryption).
+2. Add your site and secret keys to `_config.yml`. Be sure to properly encrypt your secret key using [Staticman's encrypt endpoint](https://staticman.net/docs/encryption).
 
 ```yaml
 reCaptcha:


### PR DESCRIPTION
Suggestion for docs - adding to staticman causes reCaptcha to not show in the comment form; only `_config.yml` needed modifying.

(Adding to staticman blocks the reCaptcha from showing in the site - or at least did in my [implementation](https://github.com/opening-pathways/website) of the template. Otherwise following these docs worked great for adding reCaptcha in.)

And - huge thank you for this site template *and* the fantastic documentation! I've highlighted it [here](http://openingpathways.org/everything-is-open-source) as one of the reason's we chose it for our project's blog.

