### PR TITLE
Fix missing title with custom comments

### DIFF
--- a/_includes/comments.html
+++ b/_includes/comments.html
@@ -166,6 +166,7 @@
         {% endif %}
       </section>
     {% when "custom" %}
+      <h4 class="page__comments-title">{{ comments_label }}</h4>
       <section id="custom-comments"></section>
   {% endcase %}
 </div>


### PR DESCRIPTION
Added the <h4> tag to show the comments title when custom comment provider is selected.