### PR TITLE
Open external footer links in new window

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -16,4 +16,4 @@
   </ul>
 </div>
 
-<div class="page__footer-copyright">&copy; {{ site.time | date: '%Y' }} {{ site.name | default: site.title }}. {{ site.data.ui-text[site.locale].powered_by | default: "Powered by" }} <a href="https://jekyllrb.com" rel="nofollow">Jekyll</a> &amp; <a href="https://mademistakes.com/work/minimal-mistakes-jekyll-theme/" rel="nofollow">Minimal Mistakes</a>.</div>
+<div class="page__footer-copyright">&copy; {{ site.time | date: '%Y' }} {{ site.name | default: site.title }}. {{ site.data.ui-text[site.locale].powered_by | default: "Powered by" }} <a href="https://jekyllrb.com" rel="nofollow" target="_blank">Jekyll</a> &amp; <a href="https://mademistakes.com/work/minimal-mistakes-jekyll-theme/" rel="nofollow" target="_blank">Minimal Mistakes</a>.</div>


### PR DESCRIPTION
This is a bug fix.

## Summary

The "Powered by" links in the footer area open in the same window by default. This commit changes the behaviour to open them in a new window.


## Context

This is particularly useful when hosting the project on GitHub pages or GitLab pages, and using a domain name that masks the URL in a frame, so the external links don't open under the same domain name.