### PR TITLE
adding Mastodon to social profiles in config.yml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -113,6 +113,9 @@ author:
     - label: "Website"
       icon: "fas fa-fw fa-link"
       # url: "https://your-website.com"
+    - label: "Mastodon"
+      icon: "fab fa-fw fa-mastodon"
+      # url: 
     - label: "Twitter"
       icon: "fab fa-fw fa-twitter-square"
       # url: "https://twitter.com/"
@@ -135,6 +138,9 @@ footer:
     - label: "Facebook"
       icon: "fab fa-fw fa-facebook-square"
       # url:
+    - label: "Mastodon"
+      icon: "fab fa-fw fa-mastodon"
+      # url: 
     - label: "GitHub"
       icon: "fab fa-fw fa-github"
       # url:


### PR DESCRIPTION
This is an enhancement or feature.

## Summary

<!--
  Provide a description of what your pull request changes.
-->
In the _config.yml I included the possibility to add your Mastodon profile in both the sidebar and footer. You can add your full Mastodon profile URL to the list.

