### PR TITLE
Cache "static" includes to improve build performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Enhancements
 
+- Cache "static" includes to improve build performance. [#1874](https://github.com/mmistakes/minimal-mistakes/pull/1874)
 - Make entire feature and archive items "clickable". [#1864](https://github.com/mmistakes/minimal-mistakes/pull/1864)
 - Allow custom Staticman endpoints. [#1842](https://github.com/mmistakes/minimal-mistakes/issues/1842)
 - Remove `type="text/css"` from Algolia script includes. [#1836](https://github.com/mmistakes/minimal-mistakes/pull/1836)

--- a/_config.yml
+++ b/_config.yml
@@ -226,6 +226,7 @@ plugins:
   - jekyll-gist
   - jekyll-feed
   - jemoji
+  - jekyll-include-cache
 
 # mimic GitHub Pages with --safe
 whitelist:
@@ -234,6 +235,7 @@ whitelist:
   - jekyll-gist
   - jekyll-feed
   - jemoji
+  - jekyll-include-cache
 
 
 # Archives

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -16,13 +16,13 @@
   {%- assign search_provider = site.search_provider | default: "lunr" -%}
   {%- case search_provider -%}
     {%- when "lunr" -%}
-      {% include search/lunr-search-scripts.html %}
+      {% include_cached search/lunr-search-scripts.html %}
     {%- when "google" -%}
-      {% include search/google-search-scripts.html %}
+      {% include_cached search/google-search-scripts.html %}
     {%- when "algolia" -%}
-      {% include search/algolia-search-scripts.html %}
+      {% include_cached search/algolia-search-scripts.html %}
   {%- endcase -%}
 {% endif %}
 
-{% include analytics.html %}
-{% include /comments-providers/scripts.html %}
+{% include_cached analytics.html %}
+{% include_cached /comments-providers/scripts.html %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -16,8 +16,8 @@
 
   <body class="layout--{{ page.layout | default: layout.layout }}{% if page.classes or layout.classes %}{{ page.classes | default: layout.classes | join: ' ' | prepend: ' ' }}{% endif %}">
 
-    {% include browser-upgrade.html %}
-    {% include masthead.html %}
+    {% include_cached browser-upgrade.html %}
+    {% include_cached masthead.html %}
 
     <div class="initial-content">
       {{ content }}
@@ -25,18 +25,18 @@
 
     {% if site.search == true %}
       <div class="search-content">
-        {% include search/search_form.html %}
+        {% include_cached search/search_form.html %}
       </div>
     {% endif %}
 
     <div class="page__footer">
       <footer>
         {% include footer/custom.html %}
-        {% include footer.html %}
+        {% include_cached footer.html %}
       </footer>
     </div>
 
-    {% include scripts.html %}
+    {% include_cached scripts.html %}
 
   </body>
 </html>

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -284,6 +284,7 @@ plugins:
   - jekyll-gist
   - jekyll-feed
   - jemoji
+  - jekyll-include-cache
 
 # mimic GitHub Pages with --safe
 whitelist:
@@ -292,6 +293,7 @@ whitelist:
   - jekyll-gist
   - jekyll-feed
   - jemoji
+  - jekyll-include-cache
 
 
 # Archives

--- a/docs/_docs/18-history.md
+++ b/docs/_docs/18-history.md
@@ -4,7 +4,7 @@ permalink: /docs/history/
 excerpt: "Change log of enhancements and bug fixes made to the theme."
 sidebar:
   nav: docs
-last_modified_at: 2018-10-02T11:03:51-04:00
+last_modified_at: 2018-10-04T15:41:33-04:00
 toc: true
 ---
 
@@ -12,6 +12,7 @@ toc: true
 
 ### Enhancements
 
+- Cache "static" includes to improve build performance. [#1874](https://github.com/mmistakes/minimal-mistakes/pull/1874)
 - Make entire feature and archive items "clickable". [#1864](https://github.com/mmistakes/minimal-mistakes/pull/1864)
 - Allow custom Staticman endpoints. [#1842](https://github.com/mmistakes/minimal-mistakes/issues/1842)
 - Remove `type="text/css"` from Algolia script includes. [#1836](https://github.com/mmistakes/minimal-mistakes/pull/1836)

--- a/minimal-mistakes-jekyll.gemspec
+++ b/minimal-mistakes-jekyll.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "jekyll-feed", "~> 0.10"
   spec.add_runtime_dependency "jekyll-data", "~> 1.0"
   spec.add_runtime_dependency "jemoji", "~> 0.10"
+  spec.add_runtime_dependency "jekyll-include-cache", "~> 0.1"
 
   spec.add_development_dependency "bundler", "~> 1.15"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/test/_config.yml
+++ b/test/_config.yml
@@ -200,6 +200,7 @@ plugins:
   - jekyll-gist
   - jekyll-feed
   - jemoji
+  - jekyll-include-cache
 
 # mimic GitHub Pages with --safe
 whitelist:
@@ -208,6 +209,7 @@ whitelist:
   - jekyll-gist
   - jekyll-feed
   - jemoji
+  - jekyll-include-cache
 
 
 # Archives


### PR DESCRIPTION
This is an enhancement or feature.

## Summary

Includes that are computational expensive and are called several times can potentially see a improvement in build time if cached. Includes that do not rely on the `page` context are prime candidates for caching e.g. the masthead, footer, scripts, etc.

Install [jekyll-include-cache](https://github.com/benbalter/jekyll-include-cache) and replace includes that fit this criteria using `{{ include_cached }}` tag.

[**`/test` build times (Windows 7):**](https://github.com/mmistakes/minimal-mistakes/tree/master/test)

|  | `{{ include }}` | `{{ include_cached }}` |
| --- | --- | --- |
| cold start | 11.442s | 10.633s |
| rebuild | 10.136s | 9.136s |