### PR TITLE
Revert caching for comments and analytics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 - Fix Lunr search index merging words. [#1883](https://github.com/mmistakes/minimal-mistakes/issues/1883)
 - Properly apply `relative_url` filter to internal links in header overlay `actions` array.
+- Revert cached includes (`include_cached`) for comment and analytics providers. [#1905](https://github.com/mmistakes/minimal-mistakes/issues/1905)
 
 ## [4.13.0](https://github.com/mmistakes/minimal-mistakes/releases/tag/4.13.0)
 

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -24,5 +24,5 @@
   {%- endcase -%}
 {% endif %}
 
-{% include_cached analytics.html %}
-{% include_cached /comments-providers/scripts.html %}
+{% include analytics.html %}
+{% include /comments-providers/scripts.html %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -36,7 +36,7 @@
       </footer>
     </div>
 
-    {% include_cached scripts.html %}
+    {% include scripts.html %}
 
   </body>
 </html>


### PR DESCRIPTION
This is a bug fix.

## Summary

Reverts caching for comments and analytics providers.

## Context

Fixes #1905. Although the issue only covered comments, I've uncached the `analytics.html` file as well since:

- the include that brings it in (`{% include scripts.html %}`) is now uncached
- it [uses a `page` variable](https://github.com/mmistakes/minimal-mistakes/blob/c8f4820d31c6b4c605ec96f74213df007c74c7cd/_includes/analytics.html#L1) that [can't be cached to work properly](https://github.com/mmistakes/minimal-mistakes/issues/1905#issuecomment-432040761)