### PR TITLE
Remove unnecessary closing bracket

### DIFF
--- a/docs/_docs/05-configuration.md
+++ b/docs/_docs/05-configuration.md
@@ -705,7 +705,7 @@ Analytics is disabled by default. To enable globally select one of the following
 | -------------------- | --------------------------------------------------------------- |
 | **google**           | [Google Standard Analytics](https://www.google.com/analytics/)  |
 | **google-universal** | [Google Universal Analytics](https://www.google.com/analytics/) |
-| **google-gtag**      | [Google Analytics Global Site Tag)](https://www.google.com/analytics/) |
+| **google-gtag**      | [Google Analytics Global Site Tag](https://www.google.com/analytics/) |
 | **custom**           | Other analytics providers                                       |
 
 For Google Analytics add your Tracking Code:


### PR DESCRIPTION
This is a documentation change.

## Summary

This change remove unnecessary closing bracket in this section:
https://mmistakes.github.io/minimal-mistakes/docs/configuration/#analytics
in table, row with "Google Analytics Global Site Tag)"

## Context

No, it's not related to any GitHub issue. This is just a quick fix in the documentation.