### PR TITLE
add integrity hash for Font Awesome script

### DIFF
--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -9,7 +9,7 @@
   {% endfor %}
 {% else %}
   <script src="{{ '/assets/js/main.min.js' | relative_url }}"></script>
-  <script src="https://use.fontawesome.com/releases/v5.3.1/js/all.js" integrity="sha384-kW+oWsYx3YpxvjtZjFXqazFpA7UP/MbiY4jvs+RWZo2+N94PFZ36T6TFkc9O3qoB"></script>
+  <script src="https://use.fontawesome.com/releases/v5.5.0/css/all.css" integrity="sha384-B4dIYHKNBt8Bc12p+WXckhzcICo0wtJAoU8YZTY5qE0Id1GSseTk6S+L3BlXeVIU"></script>
 {% endif %}
 
 {% if site.search == true or page.layout == "search" %}

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -9,7 +9,7 @@
   {% endfor %}
 {% else %}
   <script src="{{ '/assets/js/main.min.js' | relative_url }}"></script>
-  <script src="https://use.fontawesome.com/releases/v5.3.1/js/all.js"></script>
+  <script src="https://use.fontawesome.com/releases/v5.3.1/js/all.js" integrity="sha384-kW+oWsYx3YpxvjtZjFXqazFpA7UP/MbiY4jvs+RWZo2+N94PFZ36T6TFkc9O3qoB"></script>
 {% endif %}
 
 {% if site.search == true or page.layout == "search" %}


### PR DESCRIPTION
Proposed fix for #1920. 
As the script is loaded from an external CDN (use.fontawesome.com), its integrity must be ensured mainly for security reasons.
This hash must be updated together with the exact version of Font Awesome, as given on their website.

I have **not** added the `crossorigin="anonymous"` policy as proposed by Font Awesome as it is a quite different topic, with implications I don't fully understand.