### PR TITLE
Add rel attribute to social media links in author profile and fotter

### DIFF
--- a/_includes/author-profile-custom-links.html
+++ b/_includes/author-profile-custom-links.html
@@ -1,6 +1,6 @@
 <!--
   <li>
-    <a href="http://link-to-whatever-social-network.com/user/" itemprop="sameAs">
+    <a href="http://link-to-whatever-social-network.com/user/" itemprop="sameAs" rel="nofollow noopener noreferrer">
       <i class="fas fa-fw" aria-hidden="true"></i> Custom Social Profile Link
     </a>
   </li>

--- a/_includes/author-profile.html
+++ b/_includes/author-profile.html
@@ -75,7 +75,7 @@
 
       {% if author.keybase %}
         <li>
-          <a href="https://keybase.io/{{ author.keybase }}" itemprop="sameAs">
+          <a href="https://keybase.io/{{ author.keybase }}" itemprop="sameAs" rel="nofollow noopener noreferrer">
             <i class="fas fa-fw fa-key" aria-hidden="true"></i> Keybase
           </a>
         </li>
@@ -83,7 +83,7 @@
 
       {% if author.twitter %}
         <li>
-          <a href="https://twitter.com/{{ author.twitter }}" itemprop="sameAs">
+          <a href="https://twitter.com/{{ author.twitter }}" itemprop="sameAs" rel="nofollow noopener noreferrer">
             <i class="fab fa-fw fa-twitter-square" aria-hidden="true"></i> Twitter
           </a>
         </li>
@@ -91,7 +91,7 @@
 
       {% if author.facebook %}
         <li>
-          <a href="https://www.facebook.com/{{ author.facebook }}" itemprop="sameAs">
+          <a href="https://www.facebook.com/{{ author.facebook }}" itemprop="sameAs" rel="nofollow noopener noreferrer">
             <i class="fab fa-fw fa-facebook-square" aria-hidden="true"></i> Facebook
           </a>
         </li>
@@ -99,7 +99,7 @@
 
       {% if author.google_plus %}
         <li>
-          <a href="https://plus.google.com/{{ author.google_plus }}" itemprop="sameAs">
+          <a href="https://plus.google.com/{{ author.google_plus }}" itemprop="sameAs" rel="nofollow noopener noreferrer">
             <i class="fab fa-fw fa-google-plus-square" aria-hidden="true"></i> Google+
           </a>
         </li>
@@ -107,7 +107,7 @@
 
       {% if author.linkedin %}
         <li>
-          <a href="https://www.linkedin.com/in/{{ author.linkedin }}" itemprop="sameAs">
+          <a href="https://www.linkedin.com/in/{{ author.linkedin }}" itemprop="sameAs" rel="nofollow noopener noreferrer">
             <i class="fab fa-fw fa-linkedin" aria-hidden="true"></i> LinkedIn
           </a>
         </li>
@@ -115,7 +115,7 @@
 
       {% if author.xing %}
         <li>
-          <a href="https://www.xing.com/profile/{{ author.xing }}" itemprop="sameAs">
+          <a href="https://www.xing.com/profile/{{ author.xing }}" itemprop="sameAs" rel="nofollow noopener noreferrer">
             <i class="fab fa-fw fa-xing-square" aria-hidden="true"></i> XING
           </a>
         </li>
@@ -123,7 +123,7 @@
 
       {% if author.instagram %}
         <li>
-          <a href="https://instagram.com/{{ author.instagram }}" itemprop="sameAs">
+          <a href="https://instagram.com/{{ author.instagram }}" itemprop="sameAs" rel="nofollow noopener noreferrer">
             <i class="fab fa-fw fa-instagram" aria-hidden="true"></i> Instagram
           </a>
         </li>
@@ -131,7 +131,7 @@
 
       {% if author.tumblr %}
         <li>
-          <a href="https://{{ author.tumblr }}.tumblr.com" itemprop="sameAs">
+          <a href="https://{{ author.tumblr }}.tumblr.com" itemprop="sameAs" rel="nofollow noopener noreferrer">
             <i class="fab fa-fw fa-tumblr-square" aria-hidden="true"></i> Tumblr
           </a>
         </li>
@@ -139,7 +139,7 @@
 
       {% if author.bitbucket %}
         <li>
-          <a href="https://bitbucket.org/{{ author.bitbucket }}" itemprop="sameAs">
+          <a href="https://bitbucket.org/{{ author.bitbucket }}" itemprop="sameAs" rel="nofollow noopener noreferrer">
             <i class="fab fa-fw fa-bitbucket" aria-hidden="true"></i> Bitbucket
           </a>
         </li>
@@ -147,7 +147,7 @@
 
       {% if author.github %}
         <li>
-          <a href="https://github.com/{{ author.github }}" itemprop="sameAs">
+          <a href="https://github.com/{{ author.github }}" itemprop="sameAs" rel="nofollow noopener noreferrer">
             <i class="fab fa-fw fa-github" aria-hidden="true"></i> GitHub
           </a>
         </li>
@@ -155,7 +155,7 @@
 
       {% if author.gitlab %}
         <li>
-          <a href="https://gitlab.com/{{ author.gitlab }}" itemprop="sameAs">
+          <a href="https://gitlab.com/{{ author.gitlab }}" itemprop="sameAs" rel="nofollow noopener noreferrer">
             <i class="fab fa-fw fa-gitlab" aria-hidden="true"></i> GitLab
           </a>
         </li>
@@ -163,7 +163,7 @@
 
       {% if author.stackoverflow %}
         <li>
-          <a href="https://www.stackoverflow.com/users/{{ author.stackoverflow }}" itemprop="sameAs">
+          <a href="https://www.stackoverflow.com/users/{{ author.stackoverflow }}" itemprop="sameAs" rel="nofollow noopener noreferrer">
             <i class="fab fa-fw fa-stack-overflow" aria-hidden="true"></i> Stack Overflow
           </a>
         </li>
@@ -171,7 +171,7 @@
 
       {% if author.lastfm %}
         <li>
-          <a href="https://last.fm/user/{{ author.lastfm }}" itemprop="sameAs">
+          <a href="https://last.fm/user/{{ author.lastfm }}" itemprop="sameAs" rel="nofollow noopener noreferrer">
             <i class="fab fa-fw fa-lastfm-square" aria-hidden="true"></i> Last.fm
           </a>
         </li>
@@ -179,7 +179,7 @@
 
       {% if author.dribbble %}
         <li>
-          <a href="https://dribbble.com/{{ author.dribbble }}" itemprop="sameAs">
+          <a href="https://dribbble.com/{{ author.dribbble }}" itemprop="sameAs" rel="nofollow noopener noreferrer">
             <i class="fab fa-fw fa-dribbble" aria-hidden="true"></i> Dribbble
           </a>
         </li>
@@ -187,7 +187,7 @@
 
       {% if author.pinterest %}
         <li>
-          <a href="https://www.pinterest.com/{{ author.pinterest }}" itemprop="sameAs">
+          <a href="https://www.pinterest.com/{{ author.pinterest }}" itemprop="sameAs" rel="nofollow noopener noreferrer">
             <i class="fab fa-fw fa-pinterest" aria-hidden="true"></i> Pinterest
           </a>
         </li>
@@ -195,7 +195,7 @@
 
       {% if author.foursquare %}
         <li>
-          <a href="https://foursquare.com/{{ author.foursquare }}" itemprop="sameAs">
+          <a href="https://foursquare.com/{{ author.foursquare }}" itemprop="sameAs" rel="nofollow noopener noreferrer">
             <i class="fab fa-fw fa-foursquare" aria-hidden="true"></i> Foursquare
           </a>
         </li>
@@ -203,7 +203,7 @@
 
       {% if author.steam %}
         <li>
-          <a href="https://steamcommunity.com/id/{{ author.steam }}" itemprop="sameAs">
+          <a href="https://steamcommunity.com/id/{{ author.steam }}" itemprop="sameAs" rel="nofollow noopener noreferrer">
             <i class="fab fa-fw fa-steam" aria-hidden="true"></i> Steam
           </a>
         </li>
@@ -212,13 +212,13 @@
       {% if author.youtube %}
         {% if author.youtube contains "://" %}
           <li>
-            <a href="{{ author.youtube }}" itemprop="sameAs">
+            <a href="{{ author.youtube }}" itemprop="sameAs" rel="nofollow noopener noreferrer">
               <i class="fab fa-fw fa-youtube" aria-hidden="true"></i> YouTube
             </a>
           </li>
         {% else author.youtube %}
           <li>
-            <a href="https://www.youtube.com/user/{{ author.youtube }}" itemprop="sameAs">
+            <a href="https://www.youtube.com/user/{{ author.youtube }}" itemprop="sameAs" rel="nofollow noopener noreferrer">
               <i class="fab fa-fw fa-youtube" aria-hidden="true"></i> YouTube
             </a>
           </li>
@@ -227,7 +227,7 @@
 
       {% if author.soundcloud %}
         <li>
-          <a href="https://soundcloud.com/{{ author.soundcloud }}" itemprop="sameAs">
+          <a href="https://soundcloud.com/{{ author.soundcloud }}" itemprop="sameAs" rel="nofollow noopener noreferrer">
             <i class="fab fa-fw fa-soundcloud" aria-hidden="true"></i> SoundCloud
           </a>
         </li>
@@ -235,7 +235,7 @@
 
       {% if author.weibo %}
         <li>
-          <a href="https://www.weibo.com/{{ author.weibo }}" itemprop="sameAs">
+          <a href="https://www.weibo.com/{{ author.weibo }}" itemprop="sameAs" rel="nofollow noopener noreferrer">
             <i class="fab fa-fw fa-weibo" aria-hidden="true"></i> Weibo
           </a>
         </li>
@@ -243,7 +243,7 @@
 
       {% if author.flickr %}
         <li>
-          <a href="https://www.flickr.com/{{ author.flickr }}" itemprop="sameAs">
+          <a href="https://www.flickr.com/{{ author.flickr }}" itemprop="sameAs" rel="nofollow noopener noreferrer">
             <i class="fab fa-fw fa-flickr" aria-hidden="true"></i> Flickr
           </a>
         </li>
@@ -251,7 +251,7 @@
 
       {% if author.codepen %}
         <li>
-          <a href="https://codepen.io/{{ author.codepen }}" itemprop="sameAs">
+          <a href="https://codepen.io/{{ author.codepen }}" itemprop="sameAs" rel="nofollow noopener noreferrer">
             <i class="fab fa-fw fa-codepen" aria-hidden="true"></i> CodePen
           </a>
         </li>
@@ -259,7 +259,7 @@
 
       {% if author.vine %}
         <li>
-          <a href="https://vine.co/u/{{ author.vine }}" itemprop="sameAs">
+          <a href="https://vine.co/u/{{ author.vine }}" itemprop="sameAs" rel="nofollow noopener noreferrer">
             <i class="fab fa-fw fa-vine" aria-hidden="true"></i> Vine
           </a>
         </li>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -7,7 +7,7 @@
     {% if site.footer.links %}
       {% for link in site.footer.links %}
         {% if link.label and link.url %}
-          <li><a href="{{ link.url }}"><i class="{{ link.icon | default: 'fas fa-link' }}" aria-hidden="true"></i> {{ link.label }}</a></li>
+          <li><a href="{{ link.url }}" rel="nofollow noopener noreferrer"><i class="{{ link.icon | default: 'fas fa-link' }}" aria-hidden="true"></i> {{ link.label }}</a></li>
         {% endif %}
       {% endfor %}
     {% endif %}


### PR DESCRIPTION
This is an enhancement or feature.

## Summary

Add rel attribute to social media links. 
Set value noopener for security reason. Otherwise you can get to opener information using `window.opener.document`. 
Set value nofollow to inform search engines that we don't want to count a link as a vote for that url. Social media have no problem getting users. They don't need dofollow links.
Set value norefferer to hide referrer information when the link is clicked. This is an option for more privacy in social media. They know so much.

## Context

It's not related to any GitHub issue.