### PR TITLE
Punjabi Translation of ui-text

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Minimal Mistakes is a flexible two-column Jekyll theme. Perfect for hosting your
 - Optional [header images](https://mmistakes.github.io/minimal-mistakes/docs/layouts/#headers), [custom sidebars](https://mmistakes.github.io/minimal-mistakes/docs/layouts/#sidebars), [table of contents](https://mmistakes.github.io/minimal-mistakes/docs/helpers/#table-of-contents), [galleries](https://mmistakes.github.io/minimal-mistakes/docs/helpers/#gallery), related posts, [breadcrumb links](https://mmistakes.github.io/minimal-mistakes/docs/configuration/#breadcrumb-navigation-beta), [navigation lists](https://mmistakes.github.io/minimal-mistakes/docs/helpers/#navigation-list), and more.
 - Commenting support (powered by [Disqus](https://disqus.com/), [Facebook](https://developers.facebook.com/docs/plugins/comments), Google+, [Discourse](https://www.discourse.org/), static-based via [Staticman v1 and v2](https://staticman.net/), and custom).
 - [Google Analytics](https://www.google.com/analytics/) support.
-- UI localized text in English (default), Brazilian Portuguese (Português brasileiro), Chinese, Danish, Dutch, French (Français), German (Deutsch), Greek, Hungarian, Indonesian, Italian (Italiano), Japanese, Korean, Nepali (Nepalese), Polish, Romanian, Russian, Slovak, Spanish (Español), Swedish, Turkish (Türkçe), and Vietnamese.
+- UI localized text in English (default), Brazilian Portuguese (Português brasileiro), Chinese, Danish, Dutch, French (Français), German (Deutsch), Greek, Hungarian, Indonesian, Italian (Italiano), Japanese, Korean, Nepali (Nepalese), Polish, Punjabi (ਪੰਜਾਬੀ), Romanian, Russian, Slovak, Spanish (Español), Swedish, Turkish (Türkçe), and Vietnamese.
 
 ## Skins (Color Variations)
 

--- a/_data/ui-text.yml
+++ b/_data/ui-text.yml
@@ -1126,6 +1126,51 @@ ro: &DEFAULT_RO
 ro-RO:
   <<: *DEFAULT_RO
   
+# Punjabi
+# -----------------
+pa: &DEFAULT_PA
+  page                       : "ਸਫ਼ਾ"
+  pagination_previous        : "ਪਿਛਲਾ"
+  pagination_next            : "ਅਗਲਾ "
+  breadcrumb_home_label      : "ਘਰ"
+  breadcrumb_separator       : "/"
+  menu_label                 : "ਟੌਗਲ ਮੀਨੂ"
+  toc_label                  : "ਇਸ ਸਫ਼ੇ 'ਤੇ"
+  ext_link_label             : "ਸਿੱਧਾ ਸੰਪਰਕ"
+  less_than                  : "ਤੋਂ ਘੱਟ"
+  minute_read                : "ਮਿੰਟ ਵਿੱਚ ਪੜਿਆ ਜਾ ਸਕਦਾ ਹੈ"
+  share_on_label             : "ਸਾਂਝਾ ਕਰੋ"
+  meta_label                 :
+  tags_label                 : "ਟੈਗ"
+  categories_label           : "ਵਰਗ"
+  date_label                 : "ਅਪਡੇਟ ਕੀਤਾ:"
+  comments_label             : "ਇੱਕ ਟਿੱਪਣੀ ਛੱਡੋ"
+  comments_title             : "ਟਿੱਪਣੀਆਂ"
+  more_label                 : "ਹੋਰ ਜਾਣੋ"
+  related_label              : "ਤੁਸੀਂ ਇਸਦਾ ਆਨੰਦ ਵੀ ਲੈ ਸਕਦੇ ਹੋ"
+  follow_label               : "ਫਾਲੋ ਅੱਪ ਕਰੋ:"
+  feed_label                 : "ਫੀਡ"
+  powered_by                 : "ਦੁਆਰਾ ਸੰਚਾਲਿਤ"
+  website_label              : "ਵੈੱਬਸਾਇਟ"
+  email_label                : "ਈਮੇਲ"
+  recent_posts               : "ਹਾਲ ਹੀ ਦੇ ਪੋਸਟ"
+  undefined_wpm              : "_config.yml ਤੇ ਅਣ-ਪ੍ਰਭਾਸ਼ਿਤ ਪੈਰਾਮੀਟਰ words_per_minute"
+  comment_form_info          : "ਤੁਹਾਡਾ ਈਮੇਲ ਪਤਾ ਪ੍ਰਕਾਸ਼ਿਤ ਨਹੀਂ ਕੀਤਾ ਜਾਵੇਗਾ। ਅਨੁਮਾਨਿਤ ਸਥਾਨਾਂ ਨੂੰ ਅੰਡਰਲਾਈਨ ਕੀਤਾ ਗਿਆ ਹੈ"
+  comment_form_comment_label : "ਟਿੱਪਣੀ"
+  comment_form_md_info       : "ਮਾਰਕਡਾਊਨ ਵਰਤ ਸਕਦੇ ਹੋ।"
+  comment_form_name_label    : "ਨਾਮ"
+  comment_form_email_label   : "ਈਮੇਲ ਪਤਾ"
+  comment_form_website_label : "ਵੈਬਸਾਈਟ (ਵਿਕਲਪਿਕ)"
+  comment_btn_submit         : "ਕੋਈ ਟਿੱਪਣੀ ਭੇਜੋ"
+  comment_btn_submitted      : "ਪੇਸ਼ ਕੀਤਾ"
+  comment_success_msg        : "ਤੁਹਾਡੀਆਂ ਟਿੱਪਣੀਆਂ ਲਈ ਧੰਨਵਾਦ! ਇਹ ਮਨਜ਼ੂਰੀ ਮਿਲਣ ਦੇ ਬਾਅਦ ਸਾਈਟ 'ਤੇ ਦਿਖਾਇਆ ਜਾਵੇਗਾ।"
+  comment_error_msg          : "ਮੁਆਫ ਕਰਨਾ, ਤੁਹਾਡੀ ਅਧੀਨਗੀ ਵਿੱਚ ਕੋਈ ਗਲਤੀ ਹੋਈ ਸੀ ਕਿਰਪਾ ਕਰਕੇ ਯਕੀਨੀ ਬਣਾਓ ਕਿ ਸਾਰੇ ਲੋੜੀਂਦੇ ਖੇਤਰ ਪੂਰੇ ਹੋ ਗਏ ਹਨ ਅਤੇ ਦੁਬਾਰਾ ਕੋਸ਼ਿਸ਼ ਕਰੋ।"
+  loading_label              : "ਲੋਡ ਹੋ ਰਿਹਾ ਹੈ..."
+  search_placeholder_text    : "ਆਪਣੀ ਖੋਜ ਦੇ ਸ਼ਬਦ ਨੂੰ ਦਰਜ ਕਰੋ..."
+  results_found              : "ਨਤੀਜਾ ਮਿਲਿਆ/ਮਿਲੇ"
+  back_to_top                : "ਵਾਪਸ ਚੋਟੀ 'ਤੇ ਜਾਓ"
+pa-IN:
+  <<: *DEFAULT_PA  
 # Another locale
 # --------------
 #

--- a/docs/_pages/about.md
+++ b/docs/_pages/about.md
@@ -33,7 +33,7 @@ Minimal Mistakes is a flexible two-column Jekyll theme. Perfect for hosting your
 - Optional [header images](https://mmistakes.github.io/minimal-mistakes/docs/layouts/#headers), [custom sidebars](https://mmistakes.github.io/minimal-mistakes/docs/layouts/#sidebars), [table of contents](https://mmistakes.github.io/minimal-mistakes/docs/helpers/#table-of-contents), [galleries](https://mmistakes.github.io/minimal-mistakes/docs/helpers/#gallery), related posts, [breadcrumb links](https://mmistakes.github.io/minimal-mistakes/docs/configuration/#breadcrumb-navigation-beta), [navigation lists](https://mmistakes.github.io/minimal-mistakes/docs/helpers/#navigation-list), and more.
 - Commenting support (powered by [Disqus](https://disqus.com/), [Facebook](https://developers.facebook.com/docs/plugins/comments), Google+, [Discourse](https://www.discourse.org/), static-based via [Staticman v1 and v2](https://staticman.net/), and custom).
 - [Google Analytics](https://www.google.com/analytics/) support.
-- UI localized text in English (default), Brazilian Portuguese (Português brasileiro), Chinese, Danish, Dutch, French (Français), German (Deutsch), Greek, Hungarian, Indonesian, Italian (Italiano), Japanese, Korean, Nepali (Nepalese), Polish, Romanian, Russian, Slovak, Spanish (Español), Swedish, Turkish (Türkçe), and Vietnamese.
+- UI localized text in English (default), Brazilian Portuguese (Português brasileiro), Chinese, Danish, Dutch, French (Français), German (Deutsch), Greek, Hungarian, Indonesian, Italian (Italiano), Japanese, Korean, Nepali (Nepalese), Polish, Punjabi (ਪੰਜਾਬੀ) Romanian, Russian, Slovak, Spanish (Español), Swedish, Turkish (Türkçe), and Vietnamese.
 
 ## Demo Pages
 


### PR DESCRIPTION
There are more than 100 million native speakers of Punjabi language. I am one of them. More details about [punjabi on wikipedia](https://en.wikipedia.org/wiki/Punjabi_language).
All the punjabi translations are perfect with the following exceptions-
  - in the variable name (_config.yml and words_per_minute) which are intentionally left in english.
  - meta_label is empty

<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - Read the contributing document at https://github.com/mmistakes/minimal-mistakes#contributing
-->

<!--
  Choose one of the following by uncommenting it:
-->

<!-- This is a bug fix. -->
 **This is an enhancement or feature.** 
<!-- This is a documentation change. -->

## Summary
Add translation for ui-text in Punjabi.
<!--
  Provide a description of what your pull request changes.
-->

## Context
It's not related to any GitHub issue.
<!--
  Is this related to any GitHub issue(s)?
-->