### PR TITLE
Use privacy aware embed options for YouTube & Vimeo

### DIFF
--- a/_includes/video
+++ b/_includes/video
@@ -4,8 +4,8 @@
 <!-- Courtesy of embedresponsively.com //-->
 <div class="responsive-video-container">
 {% if video_provider == "vimeo" %}
-  <iframe src="https://player.vimeo.com/video/{{ video_id }}" frameborder="0" webkitAllowFullScreen mozallowfullscreen allowFullScreen></iframe>
+  <iframe src="https://player.vimeo.com/video/{{ video_id }}?dnt=true" frameborder="0" webkitAllowFullScreen mozallowfullscreen allowFullScreen></iframe>
 {% elsif video_provider == "youtube" %}
-  <iframe src="https://www.youtube.com/embed/{{ video_id }}" frameborder="0" allowfullscreen></iframe>
+  <iframe src="https://www.youtube-nocookie.com/embed/{{ video_id }}" frameborder="0" allowfullscreen></iframe>
 {% endif %}
 </div>

--- a/docs/_docs/14-helpers.md
+++ b/docs/_docs/14-helpers.md
@@ -173,7 +173,7 @@ And then drop-in the feature row include in the body where you'd like it to appe
 
 ## Responsive Video Embed
 
-Embed a video from YouTube or Vimeo that responsively sizes to fit the width of its parent.
+Embed a video from YouTube or Vimeo that responsively sizes to fit the width of its parent. To help with GDPR compliance, the theme is using the privacy enhanced version of both providers out of the box.
 
 | Parameter  | Required     | Description                                                |
 | ---------- | ------------ | ---------------------------------------------------------- |


### PR DESCRIPTION
As discussed in #1867.

Vimeo embed reference: https://help.vimeo.com/hc/en-us/articles/360001494447-Using-Player-Parameters

For YouTube, this embed URL is found in the 'Embed' window for any video, by scrolling down in the right pane ('Enable privacy-enhanced mode').
