### PR TITLE
Prevent current post from showing in the "You may also enjoy" (related

### DIFF
--- a/_layouts/single.html
+++ b/_layouts/single.html
@@ -84,6 +84,9 @@ layout: default
       <h4 class="page__related-title">{{ site.data.ui-text[site.locale].related_label | default: "You May Also Enjoy" }}</h4>
       <div class="grid__wrapper">
         {% for post in site.posts limit:4 %}
+          {% if post.id == page.id %}
+            {% continue %}
+          {% endif %}
           {% include archive-single.html type="grid" %}
         {% endfor %}
       </div>


### PR DESCRIPTION
posts) section

<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - Read the contributing document at https://github.com/mmistakes/minimal-mistakes#contributing
-->

<!--
  Choose one of the following by uncommenting it:
-->

This is a bug fix.
<!-- This is an enhancement or feature. -->
<!-- This is a documentation change. -->

## Summary

When I forked this repo and created my first post, I noticed that in the "You may also enjoy" section, this first post was include, which doesn't make much sense. I have added a check to skip the current post when populating the related_posts.

## Context

<!--
  Is this related to any GitHub issue(s)?
-->