### PR TITLE
Google Custom Search does not work if not using Instant Search

### DIFF
--- a/_includes/search/search_form.html
+++ b/_includes/search/search_form.html
@@ -5,7 +5,7 @@
     <input type="text" id="search" class="search-input" tabindex="-1" placeholder="{{ site.data.ui-text[site.locale].search_placeholder_text | default: 'Enter your search term...' }}" />
     <div id="results" class="results"></div>
   {%- when "google" -%}
-    <form onsubmit="return executeQuery();" id="cse-search-box-form-id">
+    <form onsubmit="return googleCustomSearchExecute();" id="cse-search-box-form-id">
     <input type="text" id="cse-search-input-box-id" class="search-input" tabindex="-1" placeholder="{{ site.data.ui-text[site.locale].search_placeholder_text | default: 'Enter your search term...' }}" />
     </form>
     <div id="results" class="results">

--- a/_layouts/search.html
+++ b/_layouts/search.html
@@ -28,7 +28,7 @@ layout: default
         <input type="text" id="search" class="search-input" tabindex="-1" placeholder="{{ site.data.ui-text[site.locale].search_placeholder_text | default: 'Enter your search term...' }}" />
         <div id="results" class="results"></div>
       {%- when "google" -%}
-        <form onsubmit="return executeQuery();" id="cse-search-box-form-id">
+        <form onsubmit="return googleCustomSearchExecute();" id="cse-search-box-form-id">
         <input type="text" id="cse-search-input-box-id" class="search-input" tabindex="-1" placeholder="{{ site.data.ui-text[site.locale].search_placeholder_text | default: 'Enter your search term...' }}" />
         </form>
         <div id="results" class="results">


### PR DESCRIPTION
fbafe58e40b1bd4a2628aef1eb5955ab57dcfaf4 renamed the function in the
scripts file, but did not rename the call sites.

This is a bug fix.

## Summary

Google Custom Search integration does not work if Instant Search is not enabled.

## Context

In my `_config.yml`, I had:

```
google:
  search_engine_id       : "my_id"
  instant_search         : # false (default), true
```

When I tried to execute a search, I got an error in the Javascript console about `executeQuery` not being defined.

As part of #1667, a function was renamed in fbafe58e40b1bd4a2628aef1eb5955ab57dcfaf4. However, the two call sites, in `_includes/search/search_form.html` and `_layouts/search.html`, were not renamed.