### PR TITLE
[Bug fix]: Added missing Staticman Spanish UI text

### DIFF
--- a/_data/ui-text.yml
+++ b/_data/ui-text.yml
@@ -70,8 +70,8 @@ es: &DEFAULT_ES
   tags_label                 : "Etiquetas:"
   categories_label           : "Categorías:"
   date_label                 : "Actualizado:"
-  comments_label             : "Comentar"
-  comments_title             :
+  comments_label             : "Dejar un comentario"
+  comments_title             : "Comentar"
   more_label                 : "Ver más"
   related_label              : "Podrías ver también"
   follow_label               : "Seguir:"


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - Read the contributing document at https://github.com/mmistakes/minimal-mistakes#contributing
-->

<!--
  Choose one of the following by uncommenting it:
-->

This is a bug fix.
<!-- This is an enhancement or feature. -->
<!-- This is a documentation change. -->

## Summary

The Spanish translation of `comment_title` is *misplaced*, while that of `comment_label` is *missing*.
<!--
  Provide a description of what your pull request changes.
-->

## Context

Taken from line 91 in `messages.php` in kekebeen/5d-eu@ec56008
<!--
  Is this related to any GitHub issue(s)?
-->