### PR TITLE
[fix] syntax error of non-english character

### DIFF
--- a/assets/js/_main.js
+++ b/assets/js/_main.js
@@ -74,7 +74,7 @@ $(document).ready(function() {
     }
   });
   // Smooth scroll on page load if there is a hash in the URL.
-  if (decodeURI(location.hash)) {
+  if (location.hash) {
     $(window).trigger("popstate");
   }
 
@@ -109,7 +109,7 @@ $(document).ready(function() {
         return;
       }
     }
-    if ('#' !== decodeURI(location.hash)) {
+    if ('#' !== location.hash) {
       history.replaceState(null, null, '#');
     }
   }));

--- a/assets/js/_main.js
+++ b/assets/js/_main.js
@@ -59,7 +59,7 @@ $(document).ready(function() {
   var smoothScrolling = false;
   $(window).bind("popstate", function (event) {
     $.smoothScroll({
-      scrollTarget: location.hash,
+      scrollTarget: decodeURI(location.hash),
       offset: -20,
       beforeScroll: function() { smoothScrolling = true; },
       afterScroll: function() { smoothScrolling = false; }
@@ -74,7 +74,7 @@ $(document).ready(function() {
     }
   });
   // Smooth scroll on page load if there is a hash in the URL.
-  if (location.hash) {
+  if (decodeURI(location.hash)) {
     $(window).trigger("popstate");
   }
 
@@ -103,13 +103,13 @@ $(document).ready(function() {
       if (top <= scrollTop && scrollTop < bottom) {
         // Mark all ancestors as active
         links[i].link.parents("li").children("a").addClass('active');
-        if (links[i].href !== location.hash) {
+        if (links[i].href !== decodeURI(location.hash)) {
           history.replaceState(null, null, links[i].href);
         }
         return;
       }
     }
-    if ('#' !== location.hash) {
+    if ('#' !== decodeURI(location.hash)) {
       history.replaceState(null, null, '#');
     }
   }));


### PR DESCRIPTION
## This is a bug fix.

Dear the make of one of the world's greatest jekyll theme.

[problem]
I found that
'Syntax Error' occurs when non-english character is included in some html elements(e.g h2, h3 ...) and 'toc' is generated based of that elements.

[debug]
Click the any element of auto generated 'toc' in the below link.
https://aliwo.github.io/swblog/series/principles_of_python/object/#%EA%B0%9D%EC%B2%B4%EC%99%80-%ED%81%B4%EB%9E%98%EC%8A%A4%EC%9D%98-%EC%A0%95%EC%9D%98

[fix]
This happens because escaped url string get right in to jquery. So I fixed it with
javascript's 'decodeURI' function! :)

<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - Read the contributing document at https://github.com/mmistakes/minimal-mistakes#contributing
-->

<!--
  Choose one of the following by uncommenting it:
-->


<!-- This is an enhancement or feature. -->
<!-- This is a documentation change. -->