### PR TITLE
Remove 'www' from Stack Overflow URL

### DIFF
--- a/_includes/author-profile.html
+++ b/_includes/author-profile.html
@@ -163,7 +163,7 @@
 
       {% if author.stackoverflow %}
         <li>
-          <a href="https://www.stackoverflow.com/users/{{ author.stackoverflow }}" itemprop="sameAs" rel="nofollow noopener noreferrer">
+          <a href="https://stackoverflow.com/users/{{ author.stackoverflow }}" itemprop="sameAs" rel="nofollow noopener noreferrer">
             <i class="fab fa-fw fa-stack-overflow" aria-hidden="true"></i> Stack Overflow
           </a>
         </li>


### PR DESCRIPTION
This is an enhancement or feature.

## Summary

**Stack Overflow** is no longer including `www` in its URLs.