### PR TITLE
Add variable for max-width

### DIFF
--- a/_sass/minimal-mistakes/_masthead.scss
+++ b/_sass/minimal-mistakes/_masthead.scss
@@ -26,7 +26,7 @@
     font-family: $sans-serif-narrow;
 
     @include breakpoint($x-large) {
-      max-width: $x-large;
+      max-width: $max-width;
     }
 
     nav {

--- a/_sass/minimal-mistakes/_page.scss
+++ b/_sass/minimal-mistakes/_page.scss
@@ -15,7 +15,7 @@
   animation-delay: 0.15s;
 
   @include breakpoint($x-large) {
-    max-width: $x-large;
+    max-width: $max-width;
   }
 }
 

--- a/_sass/minimal-mistakes/_search.scss
+++ b/_sass/minimal-mistakes/_search.scss
@@ -48,7 +48,7 @@
     animation-delay: 0.15s;
 
     @include breakpoint($x-large) {
-      max-width: $x-large;
+      max-width: $max-width;
     }
   }
 

--- a/_sass/minimal-mistakes/_variables.scss
+++ b/_sass/minimal-mistakes/_variables.scss
@@ -136,6 +136,7 @@ $medium: 768px !default;
 $medium-wide: 900px !default;
 $large: 1024px !default;
 $x-large: 1280px !default;
+$max-width: $x-large !default;
 
 /*
    Grid


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - Read the contributing document at https://github.com/mmistakes/minimal-mistakes#contributing
-->

<!--
  Choose one of the following by uncommenting it:
-->

<!-- This is a bug fix. -->
This is an enhancement or feature. 
<!-- This is a documentation change. -->

## Summary

I really don't know if you are interested in adding this to the theme. It comes to resolve a problem that is mainly there when you change the size of the browser in computers, o you have a small screen computer or an iPad. It felt that sometimes in smaller browser sizes some content was bigger, wider, than in bigger ones for no reason. 

Create a new breakpoint in between "large" and "x-large" so the size changes are a little bit more fluid.

Tune-up how the right and left sidebars and the post/page content behaves. It feels more fluid now and usually when the size of the browser decreases the content decreases. Before at some breakpoints the content was bigger than in the wider breakpoint.

Create a $max-width variable, so know the content can be wider than the larger breakpoint. This variable is applied to page, search and masthead "__inner-wrap".