### PR TITLE
Fix figures when they are inside of a list

### DIFF
--- a/_includes/figure
+++ b/_includes/figure
@@ -7,6 +7,6 @@
     {% endif %}
     alt="{% if include.alt %}{{ include.alt }}{% endif %}">
   {% if include.caption %}
-    <figcaption>{{ include.caption | markdownify | remove: "<p>" | remove: "</p>" }}</figcaption>
-  {% endif %}
-</figure>
+    <figcaption>
+      {{ include.caption | markdownify | remove: "<p>" | remove: "</p>" }}
+    </figcaption>{% endif %}</figure>


### PR DESCRIPTION
<!--
  Choose one of the following by uncommenting it:
-->

This is a bug fix.

## Summary

`</figure>` tag in in the `figure` include should be in the same line as `</figcaption>` because if it isn't jekyll adds an extra end-tag `</figure>` when the figure is inside of a list. As you can see bellow. 

![Screen Shot 2019-03-15 at 17 01 32](https://user-images.githubusercontent.com/22882880/54448563-57584500-474c-11e9-9346-69336571bde1.png)

With this... it doesn't happen and the list numbers continue as normal. 

![Screen Shot 2019-03-15 at 17 02 19](https://user-images.githubusercontent.com/22882880/54448597-6ccd6f00-474c-11e9-86f3-af30d7f32462.png)

The include has to be indented 4 spaces to be include in the list. 

I guess this is more a jekyll bug than anything else, but doing this is fixed. 
