### PR TITLE
POSH HTML5 <aside header titles >

### DIFF
--- a/_includes/toc
+++ b/_includes/toc
@@ -1,6 +1,6 @@
 <aside class="sidebar__right">
 <nav class="toc" markdown="1">
-<header><h4 class="nav__title"><i class="fas fa-{{ include.icon | default: 'file-alt' }}"></i> {{ include.title | default: site.data.ui-text[site.locale].toc_label }}</h4></header>
+<header><h1 class="nav__title"><i class="fas fa-{{ include.icon | default: 'file-alt' }}"></i> {{ include.title | default: site.data.ui-text[site.locale].toc_label }}</h1</header>
 *  Auto generated table of contents
 {:toc .toc__menu}
 </nav>


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - Read the contributing document at https://github.com/mmistakes/minimal-mistakes#contributing
-->

<!--
  Choose one of the following by uncommenting it:
-->

<!-- This is a bug fix. -->
This is an enhancement or feature.
<!-- This is a documentation change. -->

## Summary

Header titles do not start out at h4 for an outline inside certain sectioning tags such as `<aside>`.

## Context
https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/Using_HTML_sections_and_outlines
