### PR TITLE
Arithmetic fix in _form.scss

### DIFF
--- a/_sass/minimal-mistakes/_forms.scss
+++ b/_sass/minimal-mistakes/_forms.scss
@@ -25,7 +25,7 @@ form {
   }
 
   p {
-    margin-bottom: 5px / 2;
+    margin-bottom: (5px / 2);
   }
 
   ul {


### PR DESCRIPTION
This is a bug fix.
## Summary
Sass do not correctly compile division without parenthesis.