### PR TITLE
Disqus load on user request

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -32,6 +32,7 @@ comments:
   provider               : # false (default), "disqus", "discourse", "facebook", "staticman", "staticman_v2", "utterances", "custom"
   disqus:
     shortname            : # https://help.disqus.com/customer/portal/articles/466208-what-s-a-shortname-
+    ondemand             : # false (default), true
   discourse:
     server               : # https://meta.discourse.org/t/embedding-discourse-comments-via-javascript/31963 , e.g.: meta.discourse.org
   facebook:

--- a/_data/ui-text.yml
+++ b/_data/ui-text.yml
@@ -36,6 +36,7 @@ en: &DEFAULT_EN
   comment_form_name_label    : "Name"
   comment_form_email_label   : "Email address"
   comment_form_website_label : "Website (optional)"
+  comment_btn_show           : "Show comments"
   comment_btn_submit         : "Submit comment"
   comment_btn_submitted      : "Submitted"
   comment_success_msg        : "Thanks for your comment! It will show on the site once it has been approved."
@@ -89,6 +90,7 @@ es: &DEFAULT_ES
   comment_form_name_label    : "Nombre"
   comment_form_email_label   : "Dirección de correo electrónico"
   comment_form_website_label : "Sitio web (opcional)"
+  comment_btn_show           :
   comment_btn_submit         : "Enviar comentario"
   comment_btn_submitted      : "Enviado"
   comment_success_msg        : "¡Gracias por tu comentario! Se publicará una vez sea aprobado."
@@ -138,6 +140,7 @@ fr: &DEFAULT_FR
   comment_form_name_label    : "Nom"
   comment_form_email_label   : "Adresse mail"
   comment_form_website_label : "Site web (optionnel)"
+  comment_btn_show           :
   comment_btn_submit         : "Envoyer"
   comment_btn_submitted      : "Envoyé"
   comment_success_msg        : "Merci pour votre commentaire, il sera visible sur le site une fois approuvé."
@@ -189,6 +192,7 @@ tr: &DEFAULT_TR
   comment_form_name_label    : "Adınız"
   comment_form_email_label   : "Email adresiniz"
   comment_form_website_label : "Websiteniz (opsiyonel)"
+  comment_btn_show           :
   comment_btn_submit         : "Yorum Yap"
   comment_btn_submitted      : "Gönderildi"
   comment_success_msg        : "Yorumunuz için teşekkürler! Yorumunuz onaylandıktan sonra sitede gösterilecektir."
@@ -233,6 +237,7 @@ pt: &DEFAULT_PT
   comment_form_name_label    : "Nome"
   comment_form_email_label   : "Endereço Email"
   comment_form_website_label : "Site (opcional)"
+  comment_btn_show           :
   comment_btn_submit         : "Sumbeter Comentário"
   comment_btn_submitted      : "Submetido"
   comment_success_msg        : "Obrigado pelo seu comentário! Será visível no site logo que aprovado."
@@ -275,6 +280,7 @@ pt-BR:
   comment_form_name_label    : "Nome"
   comment_form_email_label   : "E-mail"
   comment_form_website_label : "Site (opcional)"
+  comment_btn_show           :
   comment_btn_submit         : "Enviar comentário"
   comment_btn_submitted      : "Enviado"
   comment_success_msg        : "Obrigado pelo seu comentário! Ele aparecerá no site assim que for aprovado."
@@ -320,6 +326,7 @@ it: &DEFAULT_IT
   comment_form_name_label    : "Nome"
   comment_form_email_label   : "Indirizzo email"
   comment_form_website_label : "Sito Web (opzionale)"
+  comment_btn_show           :
   comment_btn_submit         : "Invia commento"
   comment_btn_submitted      : "Inviato"
   comment_success_msg        : "Grazie per il tuo commento! Verrà visualizzato nel sito una volta che sarà approvato."
@@ -367,6 +374,7 @@ zh: &DEFAULT_ZH_HANS
   comment_form_name_label    : "姓名"
   comment_form_email_label   : "电子邮箱"
   comment_form_website_label : "网站（可选）"
+  comment_btn_show           :
   comment_btn_submit         : "提交评论"
   comment_btn_submitted      : "已提交"
   comment_success_msg        : "感谢您的评论！被批准后它会立即在此站点展示。"
@@ -414,6 +422,7 @@ zh-TW: &DEFAULT_ZH_HANT
   comment_form_name_label    : "名字"
   comment_form_email_label   : "電子信箱帳號"
   comment_form_website_label : "網頁 (可選填)"
+  comment_btn_show           :
   comment_btn_submit         : "送出留言"
   comment_btn_submitted      : "已送出"
   comment_success_msg        : "感謝您的留言！ 審核後將會顯示在站上。"
@@ -458,6 +467,7 @@ de: &DEFAULT_DE
   comment_form_name_label    : "Name"
   comment_form_email_label   : "E-Mail-Addresse"
   comment_form_website_label : "Webseite (optional)"
+  comment_btn_show           :
   comment_btn_submit         : "Kommentar absenden"
   comment_btn_submitted      : "Versendet"
   comment_success_msg        : "Danke für Ihren Kommentar! Er wird auf der Seite angezeigt, nachdem er geprüft wurde."
@@ -514,6 +524,7 @@ ne: &DEFAULT_NE
   comment_form_name_label    : "नाम"
   comment_form_email_label   : "इमेल ठेगाना"
   comment_form_website_label : "वेबसाइट (वैकल्पिक)"
+  comment_btn_show           :
   comment_btn_submit         : "टिप्पणी दिनुहोस् "
   comment_btn_submitted      : "टिप्पणी भयो"
   comment_success_msg        : "तपाईंको टिप्पणीको लागि धन्यवाद! एक पटक यो अनुमोदन गरेपछी यो साइटमा देखाउनेछ।"
@@ -558,6 +569,7 @@ ko: &DEFAULT_KO
   comment_form_name_label    : "이름"
   comment_form_email_label   : "이메일"
   comment_form_website_label : "웹사이트(선택사항)"
+  comment_btn_show           :
   comment_btn_submit         : "댓글 등록"
   comment_btn_submitted      : "등록됨"
   comment_success_msg        : "감사합니다! 댓글이 머지된 후 확인하실 수 있습니다."
@@ -602,6 +614,7 @@ ru: &DEFAULT_RU
   comment_form_name_label    : "Имя"
   comment_form_email_label   : "Электронная почта"
   comment_form_website_label : "Ссылка на сайт (необязательно)"
+  comment_btn_show           :
   comment_btn_submit         : "Оставить комментарий"
   comment_btn_submitted      : "Отправлено"
   comment_success_msg        : "Спасибо за Ваш комментарий! Он будет опубликован на сайте после проверки."
@@ -648,6 +661,7 @@ lt: &DEFAULT_LT
   comment_form_name_label    : "Vardas"
   comment_form_email_label   : "El. paštas"
   comment_form_website_label : "Tinklapis (nebūtina)"
+  comment_btn_show           :
   comment_btn_submit         : "Komentuoti"
   comment_btn_submitted      : "Įrašytas"
   comment_success_msg        : "Ačiū už komentarą! Jis bus parodytas kai bus patvirtintas."
@@ -692,6 +706,7 @@ gr: &DEFAULT_GR
   comment_form_name_label    : "Όνομα"
   comment_form_email_label   : "Διεύθυνση email"
   comment_form_website_label : "Ιστοσελίδα (προαιρετικό)"
+  comment_btn_show           :
   comment_btn_submit         : "Υπόβαλε ένα σχόλιο"
   comment_btn_submitted      : "Έχει υποβληθεί"
   comment_success_msg        : "Ευχαριστούμε για το σχόλιό σας! Θα εμφανιστεί στην ιστοσελίδα αφού εγκριθεί."
@@ -738,6 +753,7 @@ sv: &DEFAULT_SV
   comment_form_name_label    : "Namn"
   comment_form_email_label   : "E-post adress"
   comment_form_website_label : "Webdsida (valfritt)"
+  comment_btn_show           :
   comment_btn_submit         : "Skicka en kommentar"
   comment_btn_submitted      : "Kommentaren har tagits emot"
   comment_success_msg        : "Tack för din kommentar! Den kommer att visas på sidan så fort den har godkännts."
@@ -787,6 +803,7 @@ nl: &DEFAULT_NL
   comment_form_name_label    : "Naam"
   comment_form_email_label   : "E-mailadres"
   comment_form_website_label : "Website (optioneel)"
+  comment_btn_show           :
   comment_btn_submit         : "Commentaar toevoegen"
   comment_btn_submitted      : "Toegevoegd"
   comment_success_msg        : "Bedankt voor uw reactie! Het zal op de site worden weergegeven zodra het is goedgekeurd."
@@ -833,6 +850,7 @@ id: &DEFAULT_ID
   comment_form_name_label    : "Nama"
   comment_form_email_label   : "Alamat email"
   comment_form_website_label : "Website (opsional)"
+  comment_btn_show           :
   comment_btn_submit         : "Submit Komentar"
   comment_btn_submitted      : "Telah disubmit"
   comment_success_msg        : "Terimakasih atas komentar Anda! Komentar ini akan tampil setelah disetujui."
@@ -877,6 +895,7 @@ vi: &DEFAULT_VI
   comment_form_name_label    : "Tên"
   comment_form_email_label   : "Địa chỉ email"
   comment_form_website_label : "Website (không bắt buộc)"
+  comment_btn_show           :
   comment_btn_submit         : "Gửi bình luận"
   comment_btn_submitted      : "Đã được gửi"
   comment_success_msg        : "Cảm ơn bạn đã bình luận! Bình luận sẽ xuất hiện sau khi được duyệt."
@@ -924,6 +943,7 @@ da: &DEFAULT_DA
   comment_form_name_label    : "Navn"
   comment_form_email_label   : "E-mail"
   comment_form_website_label : "Website (frivillig)"
+  comment_btn_show           :
   comment_btn_submit         : "Send kommentar"
   comment_btn_submitted      : "Sendt"
   comment_success_msg        : "Tak for din kommentar! Den bliver vist på siden, så snart den er godkendt."
@@ -971,6 +991,7 @@ pl: &DEFAULT_PL
   comment_form_name_label    : "Imię"
   comment_form_email_label   : "Adres email"
   comment_form_website_label : "Strona www (opcjonalna)"
+  comment_btn_show           :
   comment_btn_submit         : "Skomentuj"
   comment_btn_submitted      : "Komentarz dodany"
   comment_success_msg        : "Dziękuję za Twój komentarz! Zostanie dodany po akceptacji."
@@ -1015,6 +1036,7 @@ ja: &DEFAULT_JA
   comment_form_name_label    : "名前"
   comment_form_email_label   : "メールアドレス"
   comment_form_website_label : "URL (任意)"
+  comment_btn_show           :
   comment_btn_submit         : "コメントを送信する"
   comment_btn_submitted      : "送信しました"
   comment_success_msg        : "コメントありがとうございます！　コメントは承認されるとページに表示されます。"
@@ -1061,6 +1083,7 @@ sk: &DEFAULT_SK
   comment_form_name_label    : "Meno"
   comment_form_email_label   : "Emailová adresa"
   comment_form_website_label : "Webstránka (voliteľné)"
+  comment_btn_show           :
   comment_btn_submit         : "Vlož komentár"
   comment_btn_submitted      : "Vložený"
   comment_success_msg        : "Ďakujem za tvoj komentár! Po schválení bude zobrazený na stránke."
@@ -1108,6 +1131,7 @@ hu: &DEFAULT_HU
   comment_form_name_label    : "Név"
   comment_form_email_label   : "Email cím"
   comment_form_website_label : "Honlap (nem kötelező):"
+  comment_btn_show           :
   comment_btn_submit         : "Hozzászólás elküldése"
   comment_btn_submitted      : "Hozzászólás elküldve"
   comment_success_msg        : "Köszönjük a Hozzászólást! A Hozzászólások csak előzetes moderáció után lesznek publikusak."
@@ -1155,6 +1179,7 @@ ro: &DEFAULT_RO
   comment_form_name_label    : "Nume"
   comment_form_email_label   : "Adresă de email"
   comment_form_website_label : "Site (opțional)"
+  comment_btn_show           :
   comment_btn_submit         : "Trimite comentariul"
   comment_btn_submitted      : "Trimis"
   comment_success_msg        : "Mulțumesc pentru comentariu! Va apărea pe site în momentul în care va fi aprobat."
@@ -1202,6 +1227,7 @@ pa: &DEFAULT_PA
   comment_form_name_label    : "ਨਾਮ"
   comment_form_email_label   : "ਈਮੇਲ ਪਤਾ"
   comment_form_website_label : "ਵੈਬਸਾਈਟ (ਵਿਕਲਪਿਕ)"
+  comment_btn_show           :
   comment_btn_submit         : "ਕੋਈ ਟਿੱਪਣੀ ਭੇਜੋ"
   comment_btn_submitted      : "ਪੇਸ਼ ਕੀਤਾ"
   comment_success_msg        : "ਤੁਹਾਡੀਆਂ ਟਿੱਪਣੀਆਂ ਲਈ ਧੰਨਵਾਦ! ਇਹ ਮਨਜ਼ੂਰੀ ਮਿਲਣ ਦੇ ਬਾਅਦ ਸਾਈਟ 'ਤੇ ਦਿਖਾਇਆ ਜਾਵੇਗਾ।"
@@ -1248,6 +1274,7 @@ fa: &DEFAULT_FA
   comment_form_name_label    : "نام"
   comment_form_email_label   : "پست الکترونیک"
   comment_form_website_label : "سایت اینترنتی (اختیاری)"
+  comment_btn_show           :
   comment_btn_submit         : "ارسال نظر"
   comment_btn_submitted      : "ارسال شد"
   comment_success_msg        : ".باتشکر از ارسال دیدگاه! پس از تأیید، این دیدگاه در سایت نشان داده خواهد شد"
@@ -1296,6 +1323,7 @@ ml: &DEFAULT_ML
   comment_form_name_label    : "പേര്"
   comment_form_email_label   : "ഇ-മെയിൽ"
   comment_form_website_label : "വെബ്സൈറ് (ഓപ്ഷണൽ)"
+  comment_btn_show           :
   comment_btn_submit         : "അഭിപ്രായം രേഖപ്പെടുത്തുക"
   comment_btn_submitted      : "രേഖപ്പെടുത്തി"
   comment_success_msg        : "നിങ്ങളുടെ അഭിപ്രായത്തിന് നന്ദി! ഇത് അംഗീകരിച്ചുകഴിഞ്ഞാൽ ഇത് സൈറ്റിൽ പ്രദർശിപ്പിക്കും."
@@ -1343,6 +1371,7 @@ th: &DEFAULT_TH
   comment_form_name_label    : "ชื่อ"
   comment_form_email_label   : "ที่อยู่อีเมล"
   comment_form_website_label : "เว็บไซต์ (ตัวเลือก)"
+  comment_btn_show           :
   comment_btn_submit         : "ส่งความคิดเห็น"
   comment_btn_submitted      : "ส่งเรียบร้อยแล้ว"
   comment_success_msg        : "ขอบคุณสำหรับการแสดงความคิดเห็น! ความคิดเห็นจะได้รับการแสดงหลังจากได้รับการยืนยัน"
@@ -1389,6 +1418,7 @@ hi: &DEFAULT_HI
   comment_form_name_label    : "नाम"
   comment_form_email_label   : "ईमेल पता"
   comment_form_website_label : "वेबसाइट (ऐच्छिक)"
+  comment_btn_show           :
   comment_btn_submit         : "टिप्पणी भेजें"
   comment_btn_submitted      : "प्रस्तुत"
   comment_success_msg        : "आपके कमेंट के लिए धन्यवाद! इसे स्वीकृति मिलने के बाद साइट पर दिखाया जाएगा।"

--- a/_data/ui-text.yml
+++ b/_data/ui-text.yml
@@ -326,7 +326,7 @@ it: &DEFAULT_IT
   comment_form_name_label    : "Nome"
   comment_form_email_label   : "Indirizzo email"
   comment_form_website_label : "Sito Web (opzionale)"
-  comment_btn_show           :
+  comment_btn_show           : "Mostra commenti"
   comment_btn_submit         : "Invia commento"
   comment_btn_submitted      : "Inviato"
   comment_success_msg        : "Grazie per il tuo commento! Verrà visualizzato nel sito una volta che sarà approvato."

--- a/_includes/comments-providers/disqus.html
+++ b/_includes/comments-providers/disqus.html
@@ -1,5 +1,9 @@
 {% if site.comments.disqus.shortname %}
   <script>
+    {% if site.comments.disqus.ondemand %}
+    document.querySelector('#comment-btn-show').addEventListener('click', function () {
+        this.classList.replace('align-center','hidden');
+    {% endif %}
     var disqus_config = function () {
       this.page.url = "{{ page.url | absolute_url }}";  // Replace PAGE_URL with your page's canonical URL variable
       this.page.identifier = "{{ page.id }}"; // Replace PAGE_IDENTIFIER with your page's unique identifier variable
@@ -10,6 +14,9 @@
       s.setAttribute('data-timestamp', +new Date());
       (d.head || d.body).appendChild(s);
     })();
+    {% if site.comments.disqus.ondemand %}
+    });
+    {% endif %}
   </script>
 <noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
 {% endif %}

--- a/_includes/comments.html
+++ b/_includes/comments.html
@@ -6,6 +6,9 @@
       <section id="discourse-comments"></section>
     {% when "disqus" %}
       <h4 class="page__comments-title">{{ comments_label }}</h4>
+      {% if site.comments.disqus.ondemand %}
+        <button type="submit" id="comment-btn-show" tabindex="1" class="btn btn--large btn--primary align-center" style="margin-top: 1em;">{{ site.data.ui-text[site.locale].comment_btn_show | default: "Show comments" }}</button>
+      {% endif %}
       <section id="disqus_thread"></section>
     {% when "facebook" %}
       <h4 class="page__comments-title">{{ comments_label }}</h4>

--- a/_includes/comments.html
+++ b/_includes/comments.html
@@ -7,7 +7,7 @@
     {% when "disqus" %}
       <h4 class="page__comments-title">{{ comments_label }}</h4>
       {% if site.comments.disqus.ondemand %}
-        <button type="submit" id="comment-btn-show" tabindex="1" class="btn btn--large btn--primary align-center" style="margin-top: 1em;">{{ site.data.ui-text[site.locale].comment_btn_show | default: "Show comments" }}</button>
+        <button type="submit" id="comment-btn-show" tabindex="1" class="btn btn--large btn--primary align-center" style="margin-top: 2em;">{{ site.data.ui-text[site.locale].comment_btn_show | default: "Show comments" }}</button>
       {% endif %}
       <section id="disqus_thread"></section>
     {% when "facebook" %}

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -13,6 +13,9 @@
 
 <!-- For all browsers -->
 <link rel="stylesheet" href="{{ '/assets/css/main.css' | relative_url }}">
+{% if jekyll.environment == 'production' and site.comments.provider and page.comments and site.comments.disqus.shortname and site.comments.disqus.ondemand %}
+<link rel="dns-prefetch" href="https://{{ site.comments.disqus.shortname }}.disqus.com">
+{% endif %}
 
 <!--[if IE ]>
   <style>


### PR DESCRIPTION
This is a feature.

## Summary
When enabled, it hides comments behind a button until the user click it.
On click, the button hides itself and the disqus script loads the comments.

## Context
I consider disqus scripts too _aggressive_ so I prefer to load comments only on user request to speed up page loading.

This add a new variable _site.comments.disqus.ondemand_ in _config.yml where people can enable the feature. (default to false)

Needed variables added to ui-text.yml

The button does use existing styling classes