### PR TITLE
Allow specification of RSS icon in footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -12,7 +12,7 @@
       {% endfor %}
     {% endif %}
 
-    <li><a href="{% if site.atom_feed.path %}{{ site.atom_feed.path }}{% else %}{{ '/feed.xml' | relative_url }}{% endif %}"><i class="fas fa-fw fa-rss-square" aria-hidden="true"></i> {{ site.data.ui-text[site.locale].feed_label | default: "Feed" }}</a></li>
+    <li><a href="{% if site.atom_feed.path %}{{ site.atom_feed.path }}{% else %}{{ '/feed.xml' | relative_url }}{% endif %}"><i class="{{ site.footer.atom_feed.icon | default: 'fas fa-fw fa-rss-square' }}" aria-hidden="true"></i> {{ site.data.ui-text[site.locale].feed_label | default: "Feed" }}</a></li>
   </ul>
 </div>
 


### PR DESCRIPTION
All footer icons with the exception of the RSS icon can be customized in footer.html.   This update allows for the creation of a variable named site.atom_feed.icon in _config.yml in which the icon can be specified.   For example, the format would be something like:

atom_feed:
   icon: "fas fa-rss-square fa-2x"

If no value for this is specified, the current behavior would continue.

<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - Read the contributing document at https://github.com/mmistakes/minimal-mistakes#contributing
-->

<!--
  Choose one of the following by uncommenting it:
-->

<!-- This is a bug fix. -->
This is an enhancement or feature.
<!-- This is a documentation change. -->

## Summary

<!--
  Allows you to specify a variable structure in _config.yml to support the specification of an RSS icon in the footer.
-->

## Context

<!--
  Is this related to any GitHub issue(s)?
-->