### PR TITLE
remove unneeded  type="text/javascript" from google analytics

### DIFF
--- a/_includes/analytics-providers/google.html
+++ b/_includes/analytics-providers/google.html
@@ -1,4 +1,4 @@
-<script type="text/javascript">
+<script>
   var _gaq = _gaq || [];
   _gaq.push(['_setAccount', '{{ site.analytics.google.tracking_id }}']);
   {% if site.analytics.google.anonymize_ip == true %}


### PR DESCRIPTION
This is an enhancement or feature.

## Summary

remove unneeded  type="text/javascript" from google analytics

## Context

REF: 
- https://google.github.io/styleguide/htmlcssguide.html#type_Attributes
- https://codeguide.co/#html-style-script
- https://developers.google.com/analytics/devguides/collection/analyticsjs/