### PR TITLE
Display site subtitle in masthead

### DIFF
--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -11,7 +11,12 @@
         {% unless logo_path == empty %}
           <a class="site-logo" href="{{ '/' | relative_url }}"><img src="{{ logo_path | relative_url }}" alt=""></a>
         {% endunless %}
-        <a class="site-title" href="{{ '/' | relative_url }}">{{ site.masthead_title | default: site.title }}</a>
+        <a class="site-title" href="{{ '/' | relative_url }}">{{ site.masthead_title | default: site.title }}
+	{% if site.subtitle == empty %}
+	  </a>
+	{% else %}
+	  <div class="site-subtitle">{{ site.description }}</div></a>
+        {% endif %}
         <ul class="visible-links">
           {%- for link in site.data.navigation.main -%}
             {%- if link.url contains '://' -%}

--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -12,11 +12,7 @@
           <a class="site-logo" href="{{ '/' | relative_url }}"><img src="{{ logo_path | relative_url }}" alt=""></a>
         {% endunless %}
         <a class="site-title" href="{{ '/' | relative_url }}">{{ site.masthead_title | default: site.title }}
-        {% if site.subtitle == empty %}
-	  </a>
-        {% else %}
-	  <div class="site-subtitle">{{ site.description }}</div></a>
-        {% endif %}
+	{% if site.subtitle %}<div class="site-subtitle">{{ site.description }}</div>{% endif %}
         <ul class="visible-links">
           {%- for link in site.data.navigation.main -%}
             {%- if link.url contains '://' -%}

--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -12,7 +12,7 @@
           <a class="site-logo" href="{{ '/' | relative_url }}"><img src="{{ logo_path | relative_url }}" alt=""></a>
         {% endunless %}
         <a class="site-title" href="{{ '/' | relative_url }}">{{ site.masthead_title | default: site.title }}
-        {% if site.description %}<div class="site-subtitle">{{ site.description }}</div>{% endif %}
+        {% if site.subtitle %}<div class="site-subtitle">{{ site.subtitle }}</div>{% endif %}
 	</a>
         <ul class="visible-links">
           {%- for link in site.data.navigation.main -%}

--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -12,7 +12,8 @@
           <a class="site-logo" href="{{ '/' | relative_url }}"><img src="{{ logo_path | relative_url }}" alt=""></a>
         {% endunless %}
         <a class="site-title" href="{{ '/' | relative_url }}">{{ site.masthead_title | default: site.title }}
-	{% if site.subtitle %}<div class="site-subtitle">{{ site.description }}</div>{% endif %}
+        {% if site.subtitle %}<div class="site-subtitle">{{ site.description }}</div>{% endif %}
+	</a>
         <ul class="visible-links">
           {%- for link in site.data.navigation.main -%}
             {%- if link.url contains '://' -%}

--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -12,9 +12,9 @@
           <a class="site-logo" href="{{ '/' | relative_url }}"><img src="{{ logo_path | relative_url }}" alt=""></a>
         {% endunless %}
         <a class="site-title" href="{{ '/' | relative_url }}">{{ site.masthead_title | default: site.title }}
-	{% if site.subtitle == empty %}
+        {% if site.subtitle == empty %}
 	  </a>
-	{% else %}
+        {% else %}
 	  <div class="site-subtitle">{{ site.description }}</div></a>
         {% endif %}
         <ul class="visible-links">

--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -12,7 +12,7 @@
           <a class="site-logo" href="{{ '/' | relative_url }}"><img src="{{ logo_path | relative_url }}" alt=""></a>
         {% endunless %}
         <a class="site-title" href="{{ '/' | relative_url }}">{{ site.masthead_title | default: site.title }}
-        {% if site.subtitle %}<div class="site-subtitle">{{ site.description }}</div>{% endif %}
+        {% if site.description %}<div class="site-subtitle">{{ site.description }}</div>{% endif %}
 	</a>
         <ul class="visible-links">
           {%- for link in site.data.navigation.main -%}

--- a/_sass/minimal-mistakes/_masthead.scss
+++ b/_sass/minimal-mistakes/_masthead.scss
@@ -53,6 +53,10 @@
   z-index: 20;
 }
 
+.site-subtitle {
+  font-size: $type-size-9;
+}
+
 .masthead__menu {
   float: left;
   margin-left: 0;

--- a/_sass/minimal-mistakes/_masthead.scss
+++ b/_sass/minimal-mistakes/_masthead.scss
@@ -54,7 +54,7 @@
 }
 
 .site-subtitle {
-  font-size: $type-size-9;
+  font-size: $type-size-8;
 }
 
 .masthead__menu {

--- a/_sass/minimal-mistakes/_variables.scss
+++ b/_sass/minimal-mistakes/_variables.scss
@@ -42,7 +42,6 @@ $type-size-5: 1em !default; // ~16px
 $type-size-6: 0.75em !default; // ~12px
 $type-size-7: 0.6875em !default; // ~11px
 $type-size-8: 0.625em !default; // ~10px
-$type-size-9: 0.350em !default; // ~4px
 
 /*
    Colors

--- a/_sass/minimal-mistakes/_variables.scss
+++ b/_sass/minimal-mistakes/_variables.scss
@@ -42,6 +42,7 @@ $type-size-5: 1em !default; // ~16px
 $type-size-6: 0.75em !default; // ~12px
 $type-size-7: 0.6875em !default; // ~11px
 $type-size-8: 0.625em !default; // ~10px
+$type-size-9: 0.350em !default; // ~4px
 
 /*
    Colors


### PR DESCRIPTION
<!-- This is an enhancement or feature. -->

## Summary

Displays `site.subtitle` in masthead under the site title.

## Context

Related to issue #2173 