### PR TITLE
Fixes aria issues on search form

### DIFF
--- a/_data/ui-text.yml
+++ b/_data/ui-text.yml
@@ -46,6 +46,7 @@ en: &DEFAULT_EN
   comment_error_msg          : "Sorry, there was an error with your submission. Please make sure all required fields have been completed and try again."
   loading_label              : "Loading..."
   search_placeholder_text    : "Enter your search term..."
+  search_label_text          : "Enter your search term..."
   results_found              : "Result(s) found"
   back_to_top                : "Back to top"
 en-US:

--- a/_includes/search/search_form.html
+++ b/_includes/search/search_form.html
@@ -11,7 +11,7 @@
     <div id="results" class="results"></div>
   {%- when "google" -%}
     <form onsubmit="return googleCustomSearchExecute();" id="cse-search-box-form-id">
-      <label  class="sr-only" for="cse-search-input-box-id">
+      <label class="sr-only" for="cse-search-input-box-id">
         {{ site.data.ui-text[site.locale].search_label_text | default: 'Enter your search term...' }}
       </label>
       <input type="search" id="cse-search-input-box-id" class="search-input" tabindex="-1" placeholder="{{ site.data.ui-text[site.locale].search_placeholder_text | default: 'Enter your search term...' }}" />

--- a/_includes/search/search_form.html
+++ b/_includes/search/search_form.html
@@ -2,11 +2,19 @@
 {%- assign search_provider = site.search_provider | default: "lunr" -%}
 {%- case search_provider -%}
   {%- when "lunr" -%}
-    <input type="search" id="search" aria-label="{{ site.data.ui-text[site.locale].search_label_text | default: 'Enter your search term...' }}" class="search-input" tabindex="-1" placeholder="{{ site.data.ui-text[site.locale].search_placeholder_text | default: 'Enter your search term...' }}" />
+    <form>
+      <label  class="sr-only" for="search">
+        {{ site.data.ui-text[site.locale].search_label_text | default: 'Enter your search term...' }}
+      </label>
+      <input type="search" id="search" class="search-input" tabindex="-1" placeholder="{{ site.data.ui-text[site.locale].search_placeholder_text | default: 'Enter your search term...' }}" />
+    </form>
     <div id="results" class="results"></div>
   {%- when "google" -%}
     <form onsubmit="return googleCustomSearchExecute();" id="cse-search-box-form-id">
-    <input type="search" id="cse-search-input-box-id" aria-label="{{ site.data.ui-text[site.locale].search_label_text | default: 'Enter your search term...' }}" class="search-input" tabindex="-1" placeholder="{{ site.data.ui-text[site.locale].search_placeholder_text | default: 'Enter your search term...' }}" />
+      <label  class="sr-only" for="cse-search-input-box-id">
+        {{ site.data.ui-text[site.locale].search_label_text | default: 'Enter your search term...' }}
+      </label>
+      <input type="search" id="cse-search-input-box-id" class="search-input" tabindex="-1" placeholder="{{ site.data.ui-text[site.locale].search_placeholder_text | default: 'Enter your search term...' }}" />
     </form>
     <div id="results" class="results">
         <gcse:searchresults-only></gcse:searchresults-only>

--- a/_includes/search/search_form.html
+++ b/_includes/search/search_form.html
@@ -2,14 +2,14 @@
 {%- assign search_provider = site.search_provider | default: "lunr" -%}
 {%- case search_provider -%}
   {%- when "lunr" -%}
-    <input type="search" id="search" aria-placeholder="{{ site.data.ui-text[site.locale].search_placeholder_text | default: 'Enter your search term...' }}" class="search-input" tabindex="-1" placeholder="{{ site.data.ui-text[site.locale].search_placeholder_text | default: 'Enter your search term...' }}" />
+    <input type="search" id="search" aria-label="{{ site.data.ui-text[site.locale].search_label_text | default: 'Enter your search term...' }}" class="search-input" tabindex="-1" placeholder="{{ site.data.ui-text[site.locale].search_placeholder_text | default: 'Enter your search term...' }}" />
     <div id="results" class="results"></div>
   {%- when "google" -%}
     <form onsubmit="return googleCustomSearchExecute();" id="cse-search-box-form-id">
-    <input type="search" id="cse-search-input-box-id" aria-placeholder="{{ site.data.ui-text[site.locale].search_placeholder_text | default: 'Enter your search term...' }}" class="search-input" tabindex="-1" placeholder="{{ site.data.ui-text[site.locale].search_placeholder_text | default: 'Enter your search term...' }}" />
+    <input type="search" id="cse-search-input-box-id" aria-label="{{ site.data.ui-text[site.locale].search_label_text | default: 'Enter your search term...' }}" class="search-input" tabindex="-1" placeholder="{{ site.data.ui-text[site.locale].search_placeholder_text | default: 'Enter your search term...' }}" />
     </form>
     <div id="results" class="results">
-        <gcse:searchresults-only></gcse:searchresults-only>    
+        <gcse:searchresults-only></gcse:searchresults-only>
     </div>
   {%- when "algolia" -%}
     <div class="search-searchbar"></div>

--- a/_includes/search/search_form.html
+++ b/_includes/search/search_form.html
@@ -2,8 +2,8 @@
 {%- assign search_provider = site.search_provider | default: "lunr" -%}
 {%- case search_provider -%}
   {%- when "lunr" -%}
-    <form>
-      <label  class="sr-only" for="search">
+    <form class="search-content__form">
+      <label class="sr-only" for="search">
         {{ site.data.ui-text[site.locale].search_label_text | default: 'Enter your search term...' }}
       </label>
       <input type="search" id="search" class="search-input" tabindex="-1" placeholder="{{ site.data.ui-text[site.locale].search_placeholder_text | default: 'Enter your search term...' }}" />

--- a/_includes/search/search_form.html
+++ b/_includes/search/search_form.html
@@ -1,26 +1,26 @@
 <div class="search-content__inner-wrap">
-{%- assign search_provider = site.search_provider | default: "lunr" -%}
-{%- case search_provider -%}
+  {%- assign search_provider = site.search_provider | default: "lunr" -%}
+  {%- case search_provider -%}
   {%- when "lunr" -%}
-    <form class="search-content__form">
-      <label class="sr-only" for="search">
-        {{ site.data.ui-text[site.locale].search_label_text | default: 'Enter your search term...' }}
-      </label>
-      <input type="search" id="search" class="search-input" tabindex="-1" placeholder="{{ site.data.ui-text[site.locale].search_placeholder_text | default: 'Enter your search term...' }}" />
-    </form>
-    <div id="results" class="results"></div>
+  <form class="search-content__form" onkeydown="return event.key != 'Enter';">
+    <label class="sr-only" for="search">
+      {{ site.data.ui-text[site.locale].search_label_text | default: 'Enter your search term...' }}
+    </label>
+    <input type="search" id="search" class="search-input" tabindex="-1" placeholder="{{ site.data.ui-text[site.locale].search_placeholder_text | default: 'Enter your search term...' }}" />
+  </form>
+  <div id="results" class="results"></div>
   {%- when "google" -%}
-    <form onsubmit="return googleCustomSearchExecute();" id="cse-search-box-form-id">
-      <label class="sr-only" for="cse-search-input-box-id">
-        {{ site.data.ui-text[site.locale].search_label_text | default: 'Enter your search term...' }}
-      </label>
-      <input type="search" id="cse-search-input-box-id" class="search-input" tabindex="-1" placeholder="{{ site.data.ui-text[site.locale].search_placeholder_text | default: 'Enter your search term...' }}" />
-    </form>
-    <div id="results" class="results">
-        <gcse:searchresults-only></gcse:searchresults-only>
-    </div>
+  <form onsubmit="return googleCustomSearchExecute();" id="cse-search-box-form-id">
+    <label class="sr-only" for="cse-search-input-box-id">
+      {{ site.data.ui-text[site.locale].search_label_text | default: 'Enter your search term...' }}
+    </label>
+    <input type="search" id="cse-search-input-box-id" class="search-input" tabindex="-1" placeholder="{{ site.data.ui-text[site.locale].search_placeholder_text | default: 'Enter your search term...' }}" />
+  </form>
+  <div id="results" class="results">
+    <gcse:searchresults-only></gcse:searchresults-only>
+  </div>
   {%- when "algolia" -%}
-    <div class="search-searchbar"></div>
-    <div class="search-hits"></div>
-{%- endcase -%}
+  <div class="search-searchbar"></div>
+  <div class="search-hits"></div>
+  {%- endcase -%}
 </div>

--- a/_sass/minimal-mistakes/_search.scss
+++ b/_sass/minimal-mistakes/_search.scss
@@ -50,6 +50,10 @@
     @include breakpoint($x-large) {
       max-width: $max-width;
     }
+
+    &__form {
+      background-color: transparent;
+    }
   }
 
   .search-input {

--- a/_sass/minimal-mistakes/_search.scss
+++ b/_sass/minimal-mistakes/_search.scss
@@ -51,9 +51,10 @@
       max-width: $max-width;
     }
 
-    &__form {
-      background-color: transparent;
-    }
+  }
+
+  &__form {
+    background-color: transparent;
   }
 
   .search-input {
@@ -123,6 +124,7 @@
   font-style: normal;
   text-decoration: underline;
 }
+
 .archive__item-excerpt .ais-Highlight {
   color: $primary-color;
   font-style: normal;


### PR DESCRIPTION
This is a bug fix.

## Summary
Allows search input to have aria-label defined through language conflict, which resolves the A11y issue of an input without a label.

Also removes aria-placeholder from the search label, as per [ARIA](https://www.w3.org/TR/html-aria/) 

```
Use the placeholder attribute on any element that is allowed the placeholder attribute in HTML5
Only use the aria-placeholder attribute on elements that are not allowed to have a placeholder attribute in HTML5.
```

## Context
Resolves issue: [2180](https://github.com/mmistakes/minimal-mistakes/issues/2180)