### PR TITLE
Allow Markdown in author bio

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -109,7 +109,7 @@ analytics:
 author:
   name             : "Your Name"
   avatar           : # path of avatar image, e.g. "/assets/images/bio-photo.jpg"
-  bio              : "I am an amazing person."
+  bio              : "I am an **amazing** person."
   location         : "Somewhere"
   email            :
   links:

--- a/_includes/author-profile.html
+++ b/_includes/author-profile.html
@@ -33,9 +33,9 @@
       <h3 class="author__name" itemprop="name">{{ author.name }}</h3>
     {% endif %}
     {% if author.bio %}
-      <p class="author__bio" itemprop="description">
+      <div class="author__bio" itemprop="description">
         {{ author.bio | markdownify }}
-      </p>
+      </div>
     {% endif %}
   </div>
 

--- a/_includes/author-profile.html
+++ b/_includes/author-profile.html
@@ -34,7 +34,7 @@
     {% endif %}
     {% if author.bio %}
       <p class="author__bio" itemprop="description">
-        {{ author.bio }}
+        {{ author.bio | markdownify }}
       </p>
     {% endif %}
   </div>

--- a/test/_config.yml
+++ b/test/_config.yml
@@ -96,7 +96,7 @@ analytics:
 author:
   name             : "Your Name"
   avatar           : "/assets/images/bio-photo.jpg"
-  bio              : "I am an amazing person."
+  bio              : "I am an **amazing** person."
   location         : "Somewhere"
   links:
     - label: "Your Website"


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - Read the contributing document at https://github.com/mmistakes/minimal-mistakes#contributing
-->

<!--
  Choose one of the following by uncommenting it:
-->

<!-- This is a bug fix. -->
This is an enhancement or feature.
<!-- This is a documentation change. -->

## Summary

<!--
  Provide a description of what your pull request changes.
-->

I enabled markdown in the author bio. Previously, markdown was not enabled. In other words, I added the `markdownify` Liquid Filter to `{{ author.bio }}`.

I tested this edit locally and it worked perfectly.

## Context

<!--
  Is this related to any GitHub issue(s)?
-->

I wanted to be able to write stylized text and insert links into the bio section of the author info sidebar. 
