### PR TITLE
Fix http links to use https

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -215,7 +215,7 @@ kramdown:
 # Sass/SCSS
 sass:
   sass_dir: _sass
-  style: compressed # http://sass-lang.com/documentation/file.SASS_REFERENCE.html#output_style
+  style: compressed # https://sass-lang.com/documentation/file.SASS_REFERENCE.html#output_style
 
 
 # Outputting
@@ -272,7 +272,7 @@ tag_archive:
 
 
 # HTML Compression
-# - http://jch.penibelst.de/
+# - https://jch.penibelst.de/
 compress_html:
   clippings: all
   ignore:


### PR DESCRIPTION
Every site should support https by now. Better to link the https sites right away. Both sites do support https at the time I checked.

<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - Read the contributing document at https://github.com/mmistakes/minimal-mistakes#contributing
-->

<!--
  Choose one of the following by uncommenting it:
-->

<!-- This is a bug fix. -->
<!-- This is an enhancement or feature. -->
This is a documentation change.

## Summary
I changed the protocol of some links given in the comments of the config file from http to https since all sites should make use of https in 2019
<!--
  Provide a description of what your pull request changes.
-->

## Context
This PR is not related to any GitHub issues.
<!--
  Is this related to any GitHub issue(s)?
-->