### PR TITLE
Allow per-page override of words_per_minute

### DIFF
--- a/_includes/read-time.html
+++ b/_includes/read-time.html
@@ -1,4 +1,4 @@
-{% assign words_per_minute = site.words_per_minute | default: 200 %}
+{% assign words_per_minute = page.words_per_minute | default: site.words_per_minute | default: 200 %}
 
 {% if post.read_time %}
   {% assign words = post.content | strip_html | number_of_words %}


### PR DESCRIPTION
This is an enhancement or feature.

Different languages usually have different read speeds so it makes sense for sites with multi-lingual content (like [my site](https://ibugone.com/) where I write both English and Chinese) to be able to specify `words_per_minute` on a per-page basis.

I have already fired up another PR (jekyll/jekyll#7813) to handle the counting of CJK characters "words" and in combination with this PR, Minimal Mistakes will be better in i18n.