### PR TITLE
remove extraneous space from IE conditional statement

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -14,7 +14,7 @@
 <!-- For all browsers -->
 <link rel="stylesheet" href="{{ '/assets/css/main.css' | relative_url }}">
 
-<!--[if IE ]>
+<!--[if IE]>
   <style>
     /* old IE unsupported flexbox fixes */
     .greedy-nav .site-title {


### PR DESCRIPTION
This is a bug fix. 