### PR TITLE
Added more advanced example

### DIFF
--- a/_sass/minimal-mistakes/_forms.scss
+++ b/_sass/minimal-mistakes/_forms.scss
@@ -277,8 +277,7 @@ select:focus {
 }
 
 .form-inline .radio,
-.form-inline .checkbox,
-.form-inline .radio {
+.form-inline .checkbox {
   padding-left: 0;
   margin-bottom: 0;
   vertical-align: middle;

--- a/docs/_posts/2013-01-11-markup-html-tags-and-formatting.md
+++ b/docs/_posts/2013-01-11-markup-html-tags-and-formatting.md
@@ -103,6 +103,8 @@ Do It Live
 
 ## Forms
 
+### Simple example
+
 <form>
   <fieldset>
     <legend>Personalia:</legend>
@@ -110,6 +112,34 @@ Do It Live
     Email: <input type="text" size="30"><br>
     Date of birth: <input type="text" size="10">
   </fieldset>
+</form>
+
+### Advanced example
+
+<form>
+  <fieldset class="radio">
+    <legend>Radio buttons</legend>
+    <input type="radio" id="radio-1"> <label for="radio-1">Label 1</label>
+    <input type="radio" id="radio-2"> <label for="radio-2">Label 2</label>
+  </fieldset>
+  <fieldset class="checkbox">
+    <legend>Checkboxes</legend>
+    <input type="checkbox" id="checkbox-1"> <label for="checkbox-1">Checkbox 1</label>
+    <input type="checkbox" id="checkbox-2"> <label for="checkbox-2">Checkbox 2</label>
+  </fieldset>
+  <fieldset>
+    <legend>Personalia:</legend>
+    <label>Name: <input type="text" size="30"></label>
+    <label>Email: <input type="text" size="30" placeholder="my@email.com"><span class="help-block">E-mails will not be sold</span></label>
+    <label>Date of birth: <input type="text" size="10"> <span class="help-inline">Format: 01/10/2018</span></label>
+    <label class="form-inline">Weight: <input class="input-mini" type="text" size="10"> <span class="help-inline">kg</span></label>
+    <label class="form-inline">Height: <input class="input-small" type="text" size="10"> <span class="help-inline">cm</span></label>
+  </fieldset>
+  <fieldset>
+    <label for="comment">Longer text</label>
+    <textarea id="comment"></textarea>
+  </fieldset>
+  <input type="submit" value="Submit">
 </form>
 
 ## Buttons

--- a/docs/_posts/2013-01-11-markup-html-tags-and-formatting.md
+++ b/docs/_posts/2013-01-11-markup-html-tags-and-formatting.md
@@ -114,32 +114,59 @@ Do It Live
   </fieldset>
 </form>
 
-### Advanced example
+### Advanced form example
 
-<form>
+<form class="form">
   <fieldset class="radio">
-    <legend>Radio buttons</legend>
+    <legend>Radio buttons legend</legend>
     <input type="radio" id="radio-1"> <label for="radio-1">Label 1</label>
     <input type="radio" id="radio-2"> <label for="radio-2">Label 2</label>
   </fieldset>
+  <fieldset>
+    <legend>Radio buttons legend `inline`</legend>
+    <label for="radio-1" class="radio inline"><input type="radio" id="radio-1"> Label 1</label>
+    <label for="radio-2" class="radio inline"><input type="radio" id="radio-2"> Label 2</label>
+  </fieldset>
   <fieldset class="checkbox">
-    <legend>Checkboxes</legend>
+    <legend>Checkboxes legend </legend>
     <input type="checkbox" id="checkbox-1"> <label for="checkbox-1">Checkbox 1</label>
     <input type="checkbox" id="checkbox-2"> <label for="checkbox-2">Checkbox 2</label>
   </fieldset>
   <fieldset>
-    <legend>Personalia:</legend>
-    <label>Name: <input type="text" size="30"></label>
-    <label>Email: <input type="text" size="30" placeholder="my@email.com"><span class="help-block">E-mails will not be sold</span></label>
-    <label>Date of birth: <input type="text" size="10"> <span class="help-inline">Format: 01/10/2018</span></label>
+    <legend>Checkboxes legend `inline`</legend>
+    <label for="checkbox-1" class="checkbox inline"><input type="checkbox" id="checkbox-1"> Checkbox 1</label>
+    <label for="checkbox-2" class="checkbox inline"><input type="checkbox" id="checkbox-2"> Checkbox 2</label>
+  </fieldset>
+  <fieldset>
+    <legend>Select box legend</legend>
+    <select>
+      <option>Option 1</option>
+      <option>Option 2</option>
+    </select>
+  </fieldset>
+  <fieldset>
+    <legend>Personalia legend</legend>
+    <label>Name: <input type="text" size="30"> <span class="help-inline">Write both first and lastname `help-inline`</span></label>
+    <label>Email: <input type="text" size="30" placeholder="my@email.com"><span class="help-block">E-mails will not be sold `help-block`</span></label>
+    <label>Date of birth: <input type="text" size="10"> <span class="help-inline">Format: 01/10/2018 `help-inline`</span></label>
     <label class="form-inline">Weight: <input class="input-mini" type="text" size="10"> <span class="help-inline">kg</span></label>
-    <label class="form-inline">Height: <input class="input-small" type="text" size="10"> <span class="help-inline">cm</span></label>
+    <label class="form-inline">Height: <input class="input-small" type="text" size="10"> <span class="help-block">Height is in cm `help-block`</span></label>
+  </fieldset>
+  <fieldset>
+    <legend>File legend</legend>
+    <label>File: <input type="file"></label>
+  </fieldset>
+  <fieldset>
+    <legend>Image legend</legend>
+    <label>Image: <input type="file"></label>
   </fieldset>
   <fieldset>
     <label for="comment">Longer text</label>
     <textarea id="comment"></textarea>
   </fieldset>
   <input type="submit" value="Submit">
+  <input type="button" value="Button">
+  <input type="reset" value="Reset">
 </form>
 
 ## Buttons

--- a/docs/_posts/2013-01-11-markup-html-tags-and-formatting.md
+++ b/docs/_posts/2013-01-11-markup-html-tags-and-formatting.md
@@ -148,9 +148,9 @@ Do It Live
     <legend>Personalia legend with `form-group`</legend>
     <label>Name: <input type="text" size="30"> <span class="help-inline">Write both first and lastname `help-inline`</span></label>
     <label>Email: <input type="text" size="30" placeholder="my@email.com"><span class="help-block">E-mails will not be sold `help-block`</span></label>
-    <label>Date of birth: <input type="text" size="10"> <span class="help-inline">Format: 01/10/2018 `help-inline`</span></label>
+    <label>Date of birth: <input type="text" size="10"> <small class="help-inline">Format: 01/10/2018 `help-inline`</small></label>
     <label class="form-inline">Weight: <input class="input-mini" type="text" size="10"> <span class="help-inline">kg</span></label>
-    <label class="form-inline">Height: <input class="input-small" type="text" size="10"> <span class="help-block">Height is in cm `help-block`</span></label>
+    <label class="form-inline">Height: <input class="input-small" type="text" size="10" disabled="disabled"> <span class="help-block">Height is in cm and will be calculated `help-block`</span></label>
   </fieldset>
   <fieldset>
     <legend>File legend</legend>
@@ -159,6 +159,49 @@ Do It Live
   <fieldset>
     <legend>Image legend</legend>
     <label>Image: <input type="file"></label>
+  </fieldset>
+  <fieldset>
+    <label for="comment">Longer text</label>
+    <textarea id="comment"></textarea>
+  </fieldset>
+  <input type="submit" value="Submit">
+  <input type="button" value="Button">
+  <input type="reset" value="Reset">
+</form>
+
+### Inline form
+
+<form class="form-inline">
+  <fieldset>
+    <legend>Radio buttons legend</legend>
+    <label for="radio-1" class="radio"><input type="radio" id="radio-1"> Label 1</label>
+    <label for="radio-2" class="radio"><input type="radio" id="radio-2"> Label 2</label>
+  </fieldset>
+  <fieldset>
+    <legend>Checkboxes legend </legend>
+    <label for="checkbox-1" class="checkbox"><input type="checkbox" id="checkbox-1"> Checkbox 1</label>
+    <label for="checkbox-2" class="checkbox"><input type="checkbox" id="checkbox-2"> Checkbox 2</label>
+  </fieldset>
+  <fieldset>
+    <legend>Select box legend</legend>
+    <select>
+      <option>Option 1</option>
+      <option>Option 2</option>
+    </select>
+  </fieldset>
+  <fieldset>
+    <legend>Personalia</legend>
+    <div class="form-group">
+      <label>Name: <input type="text" size="20"> <span class="help-inline">Write both first and lastname `help-inline`</span></label>
+    </div>
+    <div class="form-group">
+      <label>Email: <input type="text" size="30" placeholder="my@email.com"><span class="help-block">E-mails will not be sold</span></label>
+      <label>Date of birth: <input type="text" size="10"> <span class="help-block">Format: 01/10/2018</span></label>
+    </div>
+    <div class="form-group">
+      <label>Weight: <input class="input-mini" type="text" size="10"> <span class="help-inline">kg</span></label>
+      <label>Height: <input class="input-small" type="text" size="10"> <span class="help-inline">cm</span></label>
+    </div>
   </fieldset>
   <fieldset>
     <label for="comment">Longer text</label>

--- a/docs/_posts/2013-01-11-markup-html-tags-and-formatting.md
+++ b/docs/_posts/2013-01-11-markup-html-tags-and-formatting.md
@@ -103,7 +103,7 @@ Do It Live
 
 ## Forms
 
-### Simple example
+### Simple form example
 
 <form>
   <fieldset>
@@ -117,20 +117,20 @@ Do It Live
 ### Advanced form example
 
 <form class="form">
-  <fieldset class="radio">
+  <fieldset>
     <legend>Radio buttons legend</legend>
-    <input type="radio" id="radio-1"> <label for="radio-1">Label 1</label>
-    <input type="radio" id="radio-2"> <label for="radio-2">Label 2</label>
+    <label for="radio-1" class="radio"><input type="radio" id="radio-1"> Label 1</label>
+    <label for="radio-2" class="radio"><input type="radio" id="radio-2"> Label 2</label>
   </fieldset>
   <fieldset>
     <legend>Radio buttons legend `inline`</legend>
     <label for="radio-1" class="radio inline"><input type="radio" id="radio-1"> Label 1</label>
     <label for="radio-2" class="radio inline"><input type="radio" id="radio-2"> Label 2</label>
   </fieldset>
-  <fieldset class="checkbox">
+  <fieldset>
     <legend>Checkboxes legend </legend>
-    <input type="checkbox" id="checkbox-1"> <label for="checkbox-1">Checkbox 1</label>
-    <input type="checkbox" id="checkbox-2"> <label for="checkbox-2">Checkbox 2</label>
+    <label for="checkbox-1" class="checkbox"><input type="checkbox" id="checkbox-1"> Checkbox 1</label>
+    <label for="checkbox-2" class="checkbox"><input type="checkbox" id="checkbox-2"> Checkbox 2</label>
   </fieldset>
   <fieldset>
     <legend>Checkboxes legend `inline`</legend>
@@ -144,8 +144,8 @@ Do It Live
       <option>Option 2</option>
     </select>
   </fieldset>
-  <fieldset>
-    <legend>Personalia legend</legend>
+  <fieldset class="form-group">
+    <legend>Personalia legend with `form-group`</legend>
     <label>Name: <input type="text" size="30"> <span class="help-inline">Write both first and lastname `help-inline`</span></label>
     <label>Email: <input type="text" size="30" placeholder="my@email.com"><span class="help-block">E-mails will not be sold `help-block`</span></label>
     <label>Date of birth: <input type="text" size="10"> <span class="help-inline">Format: 01/10/2018 `help-inline`</span></label>


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - Read the contributing document at https://github.com/mmistakes/minimal-mistakes#contributing
-->

<!--
  Choose one of the following by uncommenting it:
-->

<!-- This is a bug fix. -->
This is an enhancement or feature.
<!-- This is a documentation change. -->

## Summary

<!--
  Provide a description of what your pull request changes.
-->

I have added a form example using some of the stylesheets.

The example reveals a couple of things.

- Legends for fieldsets containing radio and checkboxes should probably be left aligned?
- Fieldsets are not separated in the layout
- It is not clear what form-group is used for
- It would be cool if it was possible to make a little more structured layout when using input-mini and input-small

Right now it looks like this on /markup/markup-html-tags-and-formatting/:

![Screenshot](https://user-images.githubusercontent.com/148026/68323978-c95c1080-00c6-11ea-8c37-ffac3a96d1d6.png)

If it was possible to use the classes for some sort of alignment - e.g.

![Screenshot (22)](https://user-images.githubusercontent.com/148026/67163802-91896500-f373-11e9-891a-96e0c5d68c5a.png)

I think I more or less captured all the classes found in the code, but might be missing some.
