### PR TITLE
Add social icon color for Keybase

### DIFF
--- a/_sass/minimal-mistakes/_utilities.scss
+++ b/_sass/minimal-mistakes/_utilities.scss
@@ -253,6 +253,10 @@ body:hover .visually-hidden button {
     color: $instagram-color;
   }
 
+  .fa-keybase {
+    color: $keybase-color;
+  }
+
   .fa-lastfm,
   .fa-lastfm-square {
     color: $lastfm-color;

--- a/_sass/minimal-mistakes/_variables.scss
+++ b/_sass/minimal-mistakes/_variables.scss
@@ -86,6 +86,7 @@ $foursquare-color: #0072b1 !default;
 $github-color: #171516 !default;
 $gitlab-color: #e24329 !default;
 $instagram-color: #517fa4 !default;
+$keybase-color: #ef7639 !default;
 $lastfm-color: #d51007 !default;
 $linkedin-color: #007bb6 !default;
 $mastodon-color: #2b90d9 !default;


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - Read the contributing document at https://github.com/mmistakes/minimal-mistakes#contributing
-->

<!--
  Choose one of the following by uncommenting it:
-->

<!-- This is a bug fix. -->
This is an enhancement or feature.
<!-- This is a documentation change. -->

## Summary

This PR adds the color to the [Keybase](https://keybase.io) social icon.

## Context

This isn't related to any issues on Github.