### PR TITLE
Allow override of page excerpt in heading (via tagline)

### DIFF
--- a/_includes/page__hero.html
+++ b/_includes/page__hero.html
@@ -42,7 +42,9 @@
           {{ page.title | default: site.title | markdownify | remove: "<p>" | remove: "</p>" }}
         {% endif %}
       </h1>
-      {% if page.header.show_overlay_excerpt != false and page.excerpt %}
+      {% if page.tagline %}
+        <p class="page__lead">{{ page.tagline | markdownify | remove: "<p>" | remove: "</p>" }}</p>
+      {% elsif page.header.show_overlay_excerpt != false and page.excerpt %}
         <p class="page__lead">{{ page.excerpt | markdownify | remove: "<p>" | remove: "</p>" }}</p>
       {% endif %}
       {% if page.read_time %}


### PR DESCRIPTION
This is an enhancement or feature.

## Summary

Allow the use of `page.tagline` to override `page.excerpt` in heading area.

I want to have some custom text that more resembles a "description" of the article in the header area that's designated for the excerpt. However, manually overriding `page.excerpt` in front matter also changes the excerpt displayed in blog menu / pagination pages, which is a rather undesired impact. Using another variable like `page.tagline` to override this makes it easier to handle and more flexible to use.

For example, the text \[*Developer, system administrator, geek*\] on [my front page](https://ibugone.com/) is actually specified as `page.excerpt`:

https://github.com/iBug/iBug-source/blob/9837ea293a154b154404a18d533341dc93199cb5/index.md#L3

## Context

Not related to any existing GitHub issue. My motivation is exactly as said: The need to customize this part of the theme. Since `excerpt` is by default automatically gathered from the first few characters of the content, it's less sensible to repeat the exact stuff in page heading.

Rest assured, `tagline` isn't a special variable (not touched by Jekyll, unlike `excerpt` which may be automatically generated) and is only specified manually. I picked this name because a few other themes also uses the same name ([example](https://github.com/Gizra/garmentbox-jekyll/blob/master/_config.yml#L13)) and it's sure to be free of confusion.