### PR TITLE
Support page header (page hero) in archive-taxonomy layouts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ example/_site
 Gemfile.lock
 node_modules
 npm-debug.log*
+vendor/bundle

--- a/_config.yml
+++ b/_config.yml
@@ -251,8 +251,8 @@ whitelist:
 #  - Archive page should exist at path when using Liquid method or you can
 #    expect broken links (especially with breadcrumbs enabled)
 #  - <base_path>/tags/my-awesome-tag/index.html ~> path: /tags/
-#  - <base_path/categories/my-awesome-category/index.html ~> path: /categories/
-#  - <base_path/my-awesome-category/index.html ~> path: /
+#  - <base_path>/categories/my-awesome-category/index.html ~> path: /categories/
+#  - <base_path>/my-awesome-category/index.html ~> path: /
 category_archive:
   type: liquid
   path: /categories/

--- a/_layouts/archive-taxonomy.html
+++ b/_layouts/archive-taxonomy.html
@@ -3,11 +3,25 @@ layout: default
 author_profile: false
 ---
 
+{% if page.header.overlay_color or page.header.overlay_image or page.header.image %}
+  {% include page__hero.html %}
+{% elsif page.header.video.id and page.header.video.provider %}
+  {% include page__hero_video.html %}
+{% endif %}
+
+{% if page.url != "/" and site.breadcrumbs %}
+  {% unless paginator %}
+    {% include breadcrumbs.html %}
+  {% endunless %}
+{% endif %}
+
 <div id="main" role="main">
   {% include sidebar.html %}
 
   <div class="archive">
-    <h1 class="page__title">{{ page.title }}</h1>
+    {% unless page.header.overlay_color or page.header.overlay_image %}
+      <h1 id="page-title" class="page__title">{{ page.title }}</h1>
+    {% endunless %}
     {% for post in page.posts %}
       {% include archive-single.html %}
     {% endfor %}


### PR DESCRIPTION
This is an enhancement or feature.

## Summary

`archive` layout already supports page hero, so why not `archive-taxonomy`? Since `jekyll-archives` generates pages based on this layout, it'd be nice to have it support more beautiful layouts as well.