### PR TITLE
Fix unreadable code blocks in notices

### DIFF
--- a/_sass/minimal-mistakes/_notices.scss
+++ b/_sass/minimal-mistakes/_notices.scss
@@ -56,6 +56,10 @@
     background-color: mix(#fff, $notice-color, 95%)
   }
 
+	pre code {
+		background-color: inherit;
+	}
+
   ul {
     &:last-child {
       margin-bottom: 0; /* override*/


### PR DESCRIPTION
This is a bug fix.

Before this patch, code blocks `<pre><code>` in notices are hardly readable:

> ![before](https://user-images.githubusercontent.com/7273074/69306294-f03b4a80-0c61-11ea-95ea-01dd244feedf.png)

After this patch, they look certainly better!

> ![after](https://user-images.githubusercontent.com/7273074/69306301-f4fffe80-0c61-11ea-8cef-d66e26d757b8.png)
