### PR TITLE
Update masthead.html

### DIFF
--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -1,7 +1,7 @@
 {% if site.logo contains "://" %}
   {% capture logo_path %}{{ site.logo }}{% endcapture %}
 {% else %}
-  {% capture logo_path %}{{ site.logo | relative_url }}{%
+  {% capture logo_path %}{{ site.logo | relative_url }}{% endcapture %}
 {% endif %}
 
 <div class="masthead">

--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -1,7 +1,7 @@
 {% if site.logo contains "://" %}
   {% capture logo_path %}{{ site.logo }}{% endcapture %}
 {% else %}
-  {% capture logo_path %}{{ site.logo }}{% endcapture %}
+  {% capture logo_path %}{{ site.logo | relative_url }}{%
 {% endif %}
 
 <div class="masthead">


### PR DESCRIPTION
fix image path in masthead for relative url

This is a bug fix. 

## Summary
Absolute/relative path check {% if site.logo contains "://" %} for logo image must prepend the baseurl in case of relative path.

## Context
If you specify 'logo: "/assets/images/logoexample.png' in _config.yml, logoexample.png will not be shown in masthead unless absolute path is used.