### PR TITLE
If URL is external links to open link in new tab

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -29,6 +29,7 @@ logo                     : # path of logo image to display in the masthead, e.g.
 masthead_title           : # overrides the website title displayed in the masthead, use " " for no title
 # breadcrumbs            : false # true, false (default)
 words_per_minute         : 200
+external_link_new_tab    : true # URL will be opened using the new tab if it is an external link
 comments:
   provider               : # false (default), "disqus", "discourse", "facebook", "staticman", "staticman_v2", "utterances", "custom"
   disqus:

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -37,3 +37,7 @@
     <script src="{{ script_path }}"></script>
   {% endfor %}
 {% endif %}
+
+{% if site.external_link_new_tab %}
+<script src="{{ '/assets/js/external-link-new-tab.js' | relative_url }}"></script>
+{% endif %}

--- a/assets/js/external-link-new-tab.js
+++ b/assets/js/external-link-new-tab.js
@@ -1,0 +1,23 @@
+function handleExternalLinks () {
+    var host = location.host
+    var allLinks = document.querySelectorAll('a')
+    forEach(allLinks, function (elem, index) {
+      checkExternalLink(elem, host)
+    })
+  }
+  
+  function checkExternalLink (item, hostname) {
+    var href = item.href
+    var itemHost = href.replace(/https?:\/\/([^\/]+)(.*)/, '$1')
+    if (itemHost !== '' && itemHost !== hostname) {
+      item.target = '_blank'
+    }
+  }
+  
+  function forEach (array, callback, scope) {
+    for (var i = 0; i < array.length; ++i) {
+      callback.call(scope, array[i], i)
+    }
+  }
+  
+  handleExternalLinks ()


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - Read the contributing document at https://github.com/mmistakes/minimal-mistakes#contributing
-->

<!--
  Choose one of the following by uncommenting it:
-->

<!-- This is a bug fix. -->
This is an enhancement or feature.
<!-- This is a documentation change. -->

## Summary

I think readers always leave the current page if they click on the URL. It is a very bad experience, so I added the judgment (hostname), if the URL is an external link, open link in new tab, and if it is an internal link, change the current page

P.S. English is not my primary language, please forgive me

## Context

Not related to any existing GitHub issue.

## Demo
[https://ovvo.cc/my-develop-settings-when-reinstall/](https://ovvo.cc/my-develop-settings-when-reinstall/)