### PR TITLE
Hide posts with [hidden: true] from listings

### DIFF
--- a/_includes/documents-collection.html
+++ b/_includes/documents-collection.html
@@ -15,5 +15,7 @@
 {% endif %}
 
 {%- for post in entries -%}
-  {% include archive-single.html %}
+  {%- unless post.hidden -%}
+    {% include archive-single.html %}
+  {%- endunless -%}
 {%- endfor -%}

--- a/_includes/posts-category.html
+++ b/_includes/posts-category.html
@@ -1,3 +1,5 @@
 {%- for post in site.categories[include.taxonomy] -%}
-  {% include archive-single.html %}
+  {%- unless post.hidden -%}
+    {% include archive-single.html %}
+  {%- endunless -%}
 {%- endfor -%}

--- a/_includes/posts-tag.html
+++ b/_includes/posts-tag.html
@@ -1,3 +1,5 @@
 {%- for post in site.tags[include.taxonomy] -%}
-  {% include archive-single.html %}
+  {%- unless post.hidden -%}
+    {% include archive-single.html %}
+  {%- endunless -%}
 {%- endfor -%}


### PR DESCRIPTION
This is an enhancement or feature.

Hide posts which have `hidden: true` in their front matters from collection / category / tag listings, as is already done with `home` layout. This works for listing pages with `layout: collection OR category OR tag`.