### PR TITLE
Fix staticman v2/v3 comments not showing

### DIFF
--- a/_includes/comments.html
+++ b/_includes/comments.html
@@ -12,7 +12,7 @@
       <section class="fb-comments" data-href="{{ page.url | absolute_url }}" data-mobile="true" data-num-posts="{{ site.comments.facebook.num_posts | default: 5 }}" data-width="100%" data-colorscheme="{{ site.comments.facebook.colorscheme | default: 'light' }}"></section>
     {% when "staticman_v2" %}
       <section id="static-comments">
-        {% if site.repository and site.staticman.branch %}
+        {% if site.repository and site.comments.staticman.branch %}
           <!-- Start static comments -->
           <div class="js-comments">
             {% if site.data.comments[page.slug] %}
@@ -35,7 +35,7 @@
           <div class="page__comments-form">
             <h4 class="page__comments-title">{{ site.data.ui-text[site.locale].comments_label | default: "Leave a Comment" }}</h4>
             <p class="small">{{ site.data.ui-text[site.locale].comment_form_info | default: "Your email address will not be published. Required fields are marked" }} <span class="required">*</span></p>
-            <form id="new_comment" class="page__comments-form js-form form" method="post" action="{{ site.staticman.endpoint | default: 'https://api.staticman.net/v2/entry/' }}{{ site.repository }}/{{ site.staticman.branch }}/comments">
+            <form id="new_comment" class="page__comments-form js-form form" method="post" action="{{ site.comments.staticman.endpoint | default: 'https://api.staticman.net/v2/entry/' }}{{ site.repository }}/{{ site.comments.staticman.branch }}/comments">
               <div class="form__spinner">
                 <i class="fas fa-spinner fa-spin fa-3x fa-fw"></i>
                 <span class="sr-only">{{ site.data.ui-text[site.locale].loading_label | default: "Loading..." }}</span>


### PR DESCRIPTION
This is a bug fix.

## Summary

According to the most recent docs, `branch` and `endpoint` should be inside `site.comments.staticman` config instead of `site.staticman`.

## Context

https://mmistakes.github.io/minimal-mistakes/docs/configuration/#staticman-v3