### PR TITLE
🔧 Exclude `package-lock.json`

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -180,6 +180,7 @@ exclude:
   - log
   - node_modules
   - package.json
+  - package-lock.json
   - Rakefile
   - README
   - tmp


### PR DESCRIPTION
This is a bug fix.

## Summary

`package.json` was being removed but `package-lock.json` wasnt.

This PR fixes that.