### PR TITLE
Fix wrong newline concatenation in SEO description

### DIFF
--- a/_includes/seo.html
+++ b/_includes/seo.html
@@ -22,7 +22,7 @@
 
 {%- assign seo_description = page.description | default: page.excerpt | default: site.description -%}
 {%- if seo_description -%}
-  {%- assign seo_description = seo_description | markdownify | strip_html | strip_newlines | escape_once -%}
+  {%- assign seo_description = seo_description | markdownify | strip_html | newline_to_br | strip_newlines | replace: '<br />', ' ' | escape_once -%}
 {%- endif -%}
 
 {%- assign author = page.author | default: page.authors[0] | default: site.author -%}


### PR DESCRIPTION
This is a bug fix for #2354. See that thread for details.