### PR TITLE
Adjust comments to be compatible with compress_html

### DIFF
--- a/_includes/comments-providers/disqus.html
+++ b/_includes/comments-providers/disqus.html
@@ -1,10 +1,10 @@
 {% if site.comments.disqus.shortname %}
   <script>
     var disqus_config = function () {
-      this.page.url = "{{ page.url | absolute_url }}";  // Replace PAGE_URL with your page's canonical URL variable
-      this.page.identifier = "{{ page.id }}"; // Replace PAGE_IDENTIFIER with your page's unique identifier variable
+      this.page.url = "{{ page.url | absolute_url }}";  /* Replace PAGE_URL with your page's canonical URL variable */
+      this.page.identifier = "{{ page.id }}"; /* Replace PAGE_IDENTIFIER with your page's unique identifier variable */
     };
-    (function() { // DON'T EDIT BELOW THIS LINE
+    (function() { /* DON'T EDIT BELOW THIS LINE */
       var d = document, s = d.createElement('script');
       s.src = 'https://{{ site.comments.disqus.shortname }}.disqus.com/embed.js';
       s.setAttribute('data-timestamp', +new Date());


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - Read the contributing document at https://github.com/mmistakes/minimal-mistakes#contributing
-->

<!--
  Choose one of the following by uncommenting it:
-->

This is a bug fix. 
<!-- This is an enhancement or feature. -->
<!-- This is a documentation change. -->

## Summary

Since enabling compress_html at my page the disqus comments haven't been shown. When looking at the compressed page code I've saw that the `//` comments are also disabling the code after that as compression removed the line-breaks.
Using `/* */` for comments clearly wraps the comment and doesn't deactivate any code afterwards.

## Context

<!--
  Is this related to any GitHub issue(s)?
-->

- see also Restrictions at https://jch.penibelst.de/ 
- I added this changes to my repo, so you could see it running (and working at) https://gamue.de/
