### PR TITLE
Allow using theme without pagination

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -6,7 +6,13 @@ layout: archive
 
 <h3 class="archive__subtitle">{{ site.data.ui-text[site.locale].recent_posts | default: "Recent Posts" }}</h3>
 
-{% for post in paginator.posts %}
+{% if site.paginate %}
+  {% assign posts = paginator.posts %}
+{% else %}
+  {% assign posts = site.posts %}
+{% endif %}
+
+{% for post in posts %}
   {% include archive-single.html %}
 {% endfor %}
 


### PR DESCRIPTION
This is an enhancement or feature.

## Summary

It allows using the theme without pagination.

## Context

Right now if you get this theme, it will not show any posts on the homepage unless you add an `index.html` file and enable pagination in `_config.yml`. This change reduces this friction and some head-scratching as to why no posts are showing on the homepage.