### PR TITLE
Fix compatibility issue with paginate V2 introduced by #2378

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -6,7 +6,7 @@ layout: archive
 
 <h3 class="archive__subtitle">{{ site.data.ui-text[site.locale].recent_posts | default: "Recent Posts" }}</h3>
 
-{% if site.paginate %}
+{% if paginator %}
   {% assign posts = paginator.posts %}
 {% else %}
   {% assign posts = site.posts %}


### PR DESCRIPTION
This is a bug fix.

## Summary

The patches in #2378 introduced a huge issue when paginating collections with paginate V2 plugin, the users of which generally set `site.paginate` to `false` or omit it completely to let it default to `null`. This however made all collection indices paged with `site.posts` instead of `paginator.posts`.

Tested with Jekyll 3.8.6 and latest compatible `jekyll-paginate-v2`, the `paginator` object is available for properly-configured pages, so this change doesn't break the intended functionality of #2378, while fixes the new issue effectively.