### PR TITLE
Regression for mmistakes#2332

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+### Bug Fixes
+
+- Fix repeated site base path for masthead logo. [#2385](https://github.com/mmistakes/minimal-mistakes/pull/2385)
+
 ## [4.18.1](https://github.com/mmistakes/minimal-mistakes/releases/tag/4.18.1)
 
 ### Bug Fixes

--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -1,8 +1,4 @@
-{% if site.logo contains "://" %}
-  {% capture logo_path %}{{ site.logo }}{% endcapture %}
-{% else %}
-  {% capture logo_path %}{{ site.logo | relative_url }}{% endcapture %}
-{% endif %}
+{% capture logo_path %}{{ site.logo }}{% endcapture %}
 
 <div class="masthead">
   <div class="masthead__inner-wrap">

--- a/docs/_docs/18-history.md
+++ b/docs/_docs/18-history.md
@@ -5,9 +5,15 @@ permalink: /docs/history/
 excerpt: "Change log of enhancements and bug fixes made to the theme."
 sidebar:
   nav: docs
-last_modified_at: 2020-01-25T11:15:45-05:00
+last_modified_at: 2020-01-29T17:42:20+08:00
 toc: false
 ---
+
+## Unreleased
+
+### Bug Fixes
+
+- Fix repeated site base path for masthead logo. [#2385](https://github.com/mmistakes/minimal-mistakes/pull/2385)
 
 ## [4.18.1](https://github.com/mmistakes/minimal-mistakes/releases/tag/4.18.1)
 


### PR DESCRIPTION
This is a bug fix.

## Summary

On the merged commit of #2332 (abf29432f6e4d75a13e94a20d8a8fc93953ee9e7), there's already

<https://github.com/mmistakes/minimal-mistakes/blob/abf29432f6e4d75a13e94a20d8a8fc93953ee9e7/_includes/masthead.html#L12>

Emphasis:

```html
<img src="{{ logo_path | relative_url }}" alt="">
                       ^^^^^^^^^^^^^^
````

so the extra `relative_url` is the culprit for the duplicated base path for masthead logo when `site.baseurl` isn't resolved to `/`.

This PR resolves that bug by removing the extra `relative_url`. On a side note, I wouldn't blame the original PR suggester because the initial `{% if site.logo contains "://" %}` is rather misleading per se.

## Context

#2332 Comment: <https://github.com/mmistakes/minimal-mistakes/pull/2332#issuecomment-579856138>

cc @Geekdude