### PR TITLE
Use relative_url and absolute_url where possible

### DIFF
--- a/_includes/archive-single.html
+++ b/_includes/archive-single.html
@@ -14,13 +14,7 @@
   <article class="archive__item" itemscope itemtype="https://schema.org/CreativeWork">
     {% if include.type == "grid" and teaser %}
       <div class="archive__item-teaser">
-        <img src=
-          {% if teaser contains "://" %}
-            "{{ teaser }}"
-          {% else %}
-            "{{ teaser | relative_url }}"
-          {% endif %}
-          alt="">
+        <img src="{{ teaser | relative_url }}" alt="">
       </div>
     {% endif %}
     <h2 class="archive__item-title" itemprop="headline">

--- a/_includes/author-profile.html
+++ b/_includes/author-profile.html
@@ -8,8 +8,7 @@
 			{% assign author_src = author.avatar | relative_url %}
 
       {% if author.home %}
-				{% assign author_link = author.home | relative_url %}
-        <a href="{{ author_link }}">
+        <a href="{{ author.home | relative_url }}">
           <img src="{{ author_src }}" alt="{{ author.name }}" itemprop="image">
         </a>
       {% else %}

--- a/_includes/author-profile.html
+++ b/_includes/author-profile.html
@@ -5,14 +5,12 @@
 
   {% if author.avatar %}
     <div class="author__avatar">
-			{% assign author_src = author.avatar | relative_url %}
-
       {% if author.home %}
         <a href="{{ author.home | relative_url }}">
-          <img src="{{ author_src }}" alt="{{ author.name }}" itemprop="image">
+          <img src="{{ author.avatar | relative_url }}" alt="{{ author.name }}" itemprop="image">
         </a>
       {% else %}
-        <img src="{{ author_src }}" alt="{{ author.name }}" itemprop="image">
+        <img src="{{ author.avatar | relative_url }}" alt="{{ author.name }}" itemprop="image">
       {% endif %}
     </div>
   {% endif %}

--- a/_includes/author-profile.html
+++ b/_includes/author-profile.html
@@ -5,18 +5,10 @@
 
   {% if author.avatar %}
     <div class="author__avatar">
-      {% if author.avatar contains "://" %}
-        {% assign author_src = author.avatar %}
-      {% else %}
-        {% assign author_src = author.avatar | relative_url %}
-      {% endif %}
+			{% assign author_src = author.avatar | relative_url %}
 
       {% if author.home %}
-        {% if author.home contains "://" %}
-          {% assign author_link = author.home %}
-        {% else %}
-          {% assign author_link = author.home | relative_url %}
-        {% endif %}
+				{% assign author_link = author.home | relative_url %}
         <a href="{{ author_link }}">
           <img src="{{ author_src }}" alt="{{ author.name }}" itemprop="image">
         </a>
@@ -208,7 +200,7 @@
               <i class="fab fa-fw fa-youtube" aria-hidden="true"></i> YouTube
             </a>
           </li>
-        {% else author.youtube %}
+        {% elsif author.youtube %}
           <li>
             <a href="https://www.youtube.com/user/{{ author.youtube }}" itemprop="sameAs" rel="nofollow noopener noreferrer">
               <i class="fab fa-fw fa-youtube" aria-hidden="true"></i> YouTube

--- a/_includes/feature_row
+++ b/_includes/feature_row
@@ -7,24 +7,12 @@
 <div class="feature__wrapper">
 
   {% for f in feature_row %}
-
-    {% if f.url contains "://" %}
-      {% capture f_url %}{{ f.url }}{% endcapture %}
-    {% else %}
-      {% capture f_url %}{{ f.url | relative_url }}{% endcapture %}
-    {% endif %}
-
     <div class="feature__item{% if include.type %}--{{ include.type }}{% endif %}">
       <div class="archive__item">
         {% if f.image_path %}
           <div class="archive__item-teaser">
-            <img src=
-              {% if f.image_path contains "://" %}
-                "{{ f.image_path }}"
-              {% else %}
-                "{{ f.image_path | relative_url }}"
-              {% endif %}
-            alt="{% if f.alt %}{{ f.alt }}{% endif %}">
+            <img src="{{ f.image_path | relative_url }}"
+                 alt="{% if f.alt %}{{ f.alt }}{% endif %}">
             {% if f.image_caption %}
               <span class="archive__item-caption">{{ f.image_caption | markdownify | remove: "<p>" | remove: "</p>" }}</span>
             {% endif %}
@@ -43,7 +31,7 @@
           {% endif %}
 
           {% if f.url %}
-            <p><a href="{{ f_url }}" class="btn {{ f.btn_class }}">{{ f.btn_label | default: site.data.ui-text[site.locale].more_label | default: "Learn More" }}</a></p>
+            <p><a href="{{ f.url | relative_url }}" class="btn {{ f.btn_class }}">{{ f.btn_label | default: site.data.ui-text[site.locale].more_label | default: "Learn More" }}</a></p>
           {% endif %}
         </div>
       </div>

--- a/_includes/figure
+++ b/_includes/figure
@@ -1,12 +1,9 @@
 <figure class="{{ include.class }}">
-  <img src=
-    {% if include.image_path contains "://" %}
-      "{{ include.image_path }}"
-    {% else %}
-      "{{ include.image_path | relative_url }}"
-    {% endif %}
-    alt="{% if include.alt %}{{ include.alt }}{% endif %}">
+  <img src="{{ include.image_path | relative_url }}"
+       alt="{% if include.alt %}{{ include.alt }}{% endif %}">
   {% if include.caption %}
     <figcaption>
       {{ include.caption | markdownify | remove: "<p>" | remove: "</p>" }}
-    </figcaption>{% endif %}</figure>
+    </figcaption>
+  {% endif %}
+</figure>

--- a/_includes/gallery
+++ b/_includes/gallery
@@ -19,30 +19,14 @@
 <figure class="{{ gallery_layout }} {{ include.class }}">
   {% for img in gallery %}
     {% if img.url %}
-      <a href=
-        {% if img.url contains "://" %}
-          "{{ img.url }}"
-        {% else %}
-          "{{ img.url | relative_url }}"
-        {% endif %}
-        {% if img.title %}title="{{ img.title }}"{% endif %}
-      >
-        <img src=
-          {% if img.image_path contains "://" %}
-            "{{ img.image_path }}"
-          {% else %}
-            "{{ img.image_path | relative_url }}"
-          {% endif %}
-          alt="{% if img.alt %}{{ img.alt }}{% endif %}">
+      <a href="{{ img.url | relative_url }}"
+        {% if img.title %}title="{{ img.title }}"{% endif %}>
+          <img src="{{ img.image_path | relative_url }}"
+               alt="{% if img.alt %}{{ img.alt }}{% endif %}">
       </a>
     {% else %}
-      <img src=
-        {% if img.image_path contains "://" %}
-          "{{ img.image_path }}"
-        {% else %}
-          "{{ img.image_path | relative_url }}"
-        {% endif %}
-        alt="{% if img.alt %}{{ img.alt }}{% endif %}">
+      <img src="{{ img.image_path | relative_url }}"
+           alt="{% if img.alt %}{{ img.alt }}{% endif %}">
     {% endif %}
   {% endfor %}
   {% if include.caption %}

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -31,11 +31,6 @@
 
 {% if site.head_scripts %}
   {% for script in site.head_scripts %}
-    {% if script contains "://" %}
-      {% capture script_path %}{{ script }}{% endcapture %}
-    {% else %}
-      {% capture script_path %}{{ script | relative_url }}{% endcapture %}
-    {% endif %}
-    <script src="{{ script_path }}"></script>
+    <script src="{{ script | relative_url }}"></script>
   {% endfor %}
 {% endif %}

--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -13,13 +13,8 @@
         </a>
         <ul class="visible-links">
           {%- for link in site.data.navigation.main -%}
-            {%- if link.url contains '://' -%}
-              {%- assign url = link.url -%}
-            {%- else -%}
-              {%- assign url = link.url | relative_url -%}
-            {%- endif -%}
             <li class="masthead__menu-item">
-              <a href="{{ url }}" {% if link.description %}title="{{ link.description }}"{% endif %}>{{ link.title }}</a>
+              <a href="{{ link.url | relative_url }}"{% if link.description %} title="{{ link.description }}"{% endif %}>{{ link.title }}</a>
             </li>
           {%- endfor -%}
         </ul>

--- a/_includes/nav_list
+++ b/_includes/nav_list
@@ -9,11 +9,7 @@
       <li>
         {% if nav.url %}
           {% comment %} internal/external URL check {% endcomment %}
-          {% if nav.url contains "://" %}
-            {% assign nav_url = nav.url %}
-          {% else %}
-            {% assign nav_url = nav.url | relative_url %}
-          {% endif %}
+          {% assign nav_url = nav.url | relative_url %}
 
           <a href="{{ nav_url }}"><span class="nav__sub-title">{{ nav.title }}</span></a>
         {% else %}
@@ -24,11 +20,7 @@
         <ul>
           {% for child in nav.children %}
             {% comment %} internal/external URL check {% endcomment %}
-            {% if child.url contains "://" %}
-              {% assign child_url = child.url %}
-            {% else %}
-              {% assign child_url = child.url | relative_url %}
-            {% endif %}
+            {% assign child_url = child.url | relative_url %}
 
             {% comment %} set "active" class on current page {% endcomment %}
             {% if child.url == page.url %}

--- a/_includes/nav_list
+++ b/_includes/nav_list
@@ -16,14 +16,7 @@
         {% if nav.children != null %}
         <ul>
           {% for child in nav.children %}
-            {% comment %} set "active" class on current page {% endcomment %}
-            {% if child.url == page.url %}
-              {% assign active = "active" %}
-            {% else %}
-              {% assign active = "" %}
-            {% endif %}
-
-            <li><a href="{{ child.url | relative_url }}" class="{{ active }}">{{ child.title }}</a></li>
+            <li><a href="{{ child.url | relative_url }}"{% if child.url == page.url %} class="active"{% endif %}>{{ child.title }}</a></li>
           {% endfor %}
         </ul>
         {% endif %}

--- a/_includes/nav_list
+++ b/_includes/nav_list
@@ -8,10 +8,7 @@
     {% for nav in navigation %}
       <li>
         {% if nav.url %}
-          {% comment %} internal/external URL check {% endcomment %}
-          {% assign nav_url = nav.url | relative_url %}
-
-          <a href="{{ nav_url }}"><span class="nav__sub-title">{{ nav.title }}</span></a>
+          <a href="{{ nav.url | relative_url }}"><span class="nav__sub-title">{{ nav.title }}</span></a>
         {% else %}
           <span class="nav__sub-title">{{ nav.title }}</span>
         {% endif %}
@@ -19,9 +16,6 @@
         {% if nav.children != null %}
         <ul>
           {% for child in nav.children %}
-            {% comment %} internal/external URL check {% endcomment %}
-            {% assign child_url = child.url | relative_url %}
-
             {% comment %} set "active" class on current page {% endcomment %}
             {% if child.url == page.url %}
               {% assign active = "active" %}
@@ -29,7 +23,7 @@
               {% assign active = "" %}
             {% endif %}
 
-            <li><a href="{{ child_url }}" class="{{ active }}">{{ child.title }}</a></li>
+            <li><a href="{{ child.url | relative_url }}" class="{{ active }}">{{ child.title }}</a></li>
           {% endfor %}
         </ul>
         {% endif %}

--- a/_includes/page__hero.html
+++ b/_includes/page__hero.html
@@ -1,20 +1,6 @@
-{% if page.header.image contains "://" %}
-  {% capture img_path %}{{ page.header.image }}{% endcapture %}
-{% else %}
-  {% capture img_path %}{{ page.header.image | relative_url }}{% endcapture %}
-{% endif %}
-
-{% if page.header.cta_url contains "://" %}
-  {% capture cta_path %}{{ page.header.cta_url }}{% endcapture %}
-{% else %}
-  {% capture cta_path %}{{ page.header.cta_url | relative_url }}{% endcapture %}
-{% endif %}
-
-{% if page.header.overlay_image contains "://" %}
-  {% capture overlay_img_path %}{{ page.header.overlay_image }}{% endcapture %}
-{% elsif page.header.overlay_image %}
-  {% capture overlay_img_path %}{{ page.header.overlay_image | relative_url }}{% endcapture %}
-{% endif %}
+{% capture img_path %}{{ page.header.image | relative_url }}{% endcapture %}
+{% capture cta_path %}{{ page.header.cta_url | relative_url }}{% endcapture %}
+{% capture overlay_img_path %}{{ page.header.overlay_image | relative_url }}{% endcapture %}
 
 {% if page.header.overlay_filter contains "rgba" %}
   {% capture overlay_filter %}{{ page.header.overlay_filter }}{% endcapture %}
@@ -56,12 +42,7 @@
       {% if page.header.actions %}
         <p>
         {% for action in page.header.actions %}
-          {% if action.url contains "://" %}
-            {% assign url = action.url %}
-          {% else %}
-            {% assign url = action.url | relative_url %}
-          {% endif %}
-          <a href="{{ url }}" class="btn btn--light-outline btn--large">{{ action.label | default: site.data.ui-text[site.locale].more_label | default: "Learn More" }}</a>
+          <a href="{{ action.url | relative_url }}" class="btn btn--light-outline btn--large">{{ action.label | default: site.data.ui-text[site.locale].more_label | default: "Learn More" }}</a>
         {% endfor %}
       {% endif %}
     </div>

--- a/_includes/page__hero.html
+++ b/_includes/page__hero.html
@@ -1,5 +1,3 @@
-{% capture img_path %}{{ page.header.image | relative_url }}{% endcapture %}
-{% capture cta_path %}{{ page.header.cta_url | relative_url }}{% endcapture %}
 {% capture overlay_img_path %}{{ page.header.overlay_image | relative_url }}{% endcapture %}
 
 {% if page.header.overlay_filter contains "rgba" %}
@@ -37,7 +35,7 @@
         <p class="page__meta"><i class="far fa-clock" aria-hidden="true"></i> {% include read-time.html %}</p>
       {% endif %}
       {% if page.header.cta_url %}
-        <p><a href="{{ cta_path }}" class="btn btn--light-outline btn--large">{{ page.header.cta_label | default: site.data.ui-text[site.locale].more_label | default: "Learn More" }}</a></p>
+        <p><a href="{{ page.header.cta_url | relative_url }}" class="btn btn--light-outline btn--large">{{ page.header.cta_label | default: site.data.ui-text[site.locale].more_label | default: "Learn More" }}</a></p>
       {% endif %}
       {% if page.header.actions %}
         <p>
@@ -47,7 +45,7 @@
       {% endif %}
     </div>
   {% else %}
-    <img src="{{ img_path }}" alt="{{ image_description }}" class="page__hero-image">
+    <img src="{{ pade.header.image | relative_url }}" alt="{{ image_description }}" class="page__hero-image">
   {% endif %}
   {% if page.header.caption %}
     <span class="page__hero-caption">{{ page.header.caption | markdownify | remove: "<p>" | remove: "</p>" }}</span>

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -1,11 +1,6 @@
 {% if site.footer_scripts %}
   {% for script in site.footer_scripts %}
-    {% if script contains "://" %}
-      {% capture script_path %}{{ script }}{% endcapture %}
-    {% else %}
-      {% capture script_path %}{{ script | relative_url }}{% endcapture %}
-    {% endif %}
-    <script src="{{ script_path }}"></script>
+    <script src="{{ script | relative_url }}"></script>
   {% endfor %}
 {% else %}
   <script src="{{ '/assets/js/main.min.js' | relative_url }}"></script>
@@ -29,11 +24,6 @@
 
 {% if site.after_footer_scripts %}
   {% for script in site.after_footer_scripts %}
-    {% if script contains "://" %}
-      {% capture script_path %}{{ script }}{% endcapture %}
-    {% else %}
-      {% capture script_path %}{{ script | relative_url }}{% endcapture %}
-    {% endif %}
-    <script src="{{ script_path }}"></script>
+    <script src="{{ script | relative_url }}"></script>
   {% endfor %}
 {% endif %}

--- a/_includes/seo.html
+++ b/_includes/seo.html
@@ -32,22 +32,13 @@
   {%- assign author_twitter = author.twitter | replace: "@", "" -%}
 {%- endif -%}
 
-{%- assign page_large_image = page.header.og_image | default: page.header.overlay_image | default: page.header.image -%}
-{%- unless page_large_image contains '://' -%}
-  {%- assign page_large_image = page_large_image | absolute_url -%}
-{%- endunless -%}
+{%- assign page_large_image = page.header.og_image | default: page.header.overlay_image | default: page.header.image | absolute_url -%}
 {%- assign page_large_image = page_large_image | escape -%}
 
-{%- assign page_teaser_image = page.header.teaser | default: site.og_image -%}
-{%- unless page_teaser_image contains '://' -%}
-  {%- assign page_teaser_image = page_teaser_image | absolute_url -%}
-{%- endunless -%}
+{%- assign page_teaser_image = page.header.teaser | default: site.og_image | absolute_url -%}
 {%- assign page_teaser_image = page_teaser_image | escape -%}
 
-{%- assign site_og_image = site.og_image -%}
-{%- unless site_og_image contains '://' -%}
-  {%- assign site_og_image = site_og_image | absolute_url -%}
-{%- endunless -%}
+{%- assign site_og_image = site.og_image | absolute_url -%}
 {%- assign site_og_image = site_og_image | escape -%}
 
 {%- if page.date -%}

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -4,13 +4,8 @@
   {% if page.sidebar %}
     {% for s in page.sidebar %}
       {% if s.image %}
-        <img src=
-        {% if s.image contains "://" %}
-          "{{ s.image }}"
-        {% else %}
-          "{{ s.image | relative_url }}"
-        {% endif %}
-        alt="{% if s.image_alt %}{{ s.image_alt }}{% endif %}">
+        <img src="{{ s.image | relative_url }}"
+             alt="{% if s.image_alt %}{{ s.image_alt }}{% endif %}">
       {% endif %}
       {% if s.title %}<h3>{{ s.title }}</h3>{% endif %}
       {% if s.text %}{{ s.text | markdownify }}{% endif %}

--- a/assets/js/lunr/lunr-store.js
+++ b/assets/js/lunr/lunr-store.js
@@ -43,12 +43,7 @@ var store = [
         "categories": {{ doc.categories | jsonify }},
         "tags": {{ doc.tags | jsonify }},
         "url": {{ doc.url | absolute_url | jsonify }},
-        "teaser":
-          {%- if teaser contains "://" -%}
-            {{ teaser | jsonify }}
-          {%- else -%}
-            {{ teaser | absolute_url | jsonify }}
-          {%- endif -%}
+        "teaser": {{ teaser | absolute_url | jsonify }}
       }{%- unless forloop.last and l -%},{%- endunless -%}
     {%- endfor -%}
   {%- endfor -%}]


### PR DESCRIPTION
This is an enhancement or feature.

## Summary

Since Jekyll 3.7.0 the `relative_url` filter does nothing when given an absolute URL, which eliminates the need to manually check for `url contains "://"`. This saves a lot of effort when coding.

A similar behavior for the `absolute_url` filter had already been introduced earlier in jekyll/jekyll#5789 and was released with Jekyll 3.5.

I ran both `grep -nrF 'contains "://"'` and `grep -nrF "contains '://'"` (single- vs. double-quotes) and reviewed every single occurrence of them, and refactored wherever possible / makes sense.

Jekyll 3.6 would no longer be compatible with this theme after merging this PR.

## Context

https://github.com/mmistakes/minimal-mistakes/pull/2385#issuecomment-579882236