### PR TITLE
Masthead: Open absolute links in new tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Enhancements
 
 - Bump Jekyll gem dependency to `v3.7`.
+- Open external masthead links in new tab. [#2392](https://github.com/mmistakes/minimal-mistakes/pull/2392)
 
 ### Bug Fixes
 

--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -13,13 +13,12 @@
         </a>
         <ul class="visible-links">
           {%- for link in site.data.navigation.main -%}
-            {%- if link.url contains '://' -%}
-              {%- assign url = link.url -%}
-            {%- else -%}
-              {%- assign url = link.url | relative_url -%}
-            {%- endif -%}
             <li class="masthead__menu-item">
-              <a href="{{ url }}" {% if link.description %}title="{{ link.description }}"{% endif %}>{{ link.title }}</a>
+              <a href="{{ link.url | relative_url }}"
+                {% if link.url contains "://" %}target="_blank"{% endif %}
+                {% if link.description %}title="{{ link.description }}"{% endif %}>
+                {{ link.title }}
+              </a>
             </li>
           {%- endfor -%}
         </ul>

--- a/docs/_docs/18-history.md
+++ b/docs/_docs/18-history.md
@@ -14,6 +14,7 @@ toc: false
 ### Enhancements
 
 - Bump Jekyll gem dependency to `v3.7`.
+- Open external masthead links in new tab. [#2392](https://github.com/mmistakes/minimal-mistakes/pull/2392)
 
 ### Bug Fixes
 


### PR DESCRIPTION
This is an enhancement or feature.

## Summary

If a masthead link contains `://`, open it in a new tab via `target="_blank"`

## Context

#2388