### PR TITLE
box-shadow on radio buttons and checkboxes look ugly

### DIFF
--- a/_sass/minimal-mistakes/_forms.scss
+++ b/_sass/minimal-mistakes/_forms.scss
@@ -107,6 +107,7 @@ input[type="radio"] {
   cursor: pointer;
   border-radius: 0;
   border: 0 \9;
+  box-shadow: none;
 }
 
 input[type="checkbox"],
@@ -119,7 +120,6 @@ input[type="radio"] {
 
 input[type="image"] {
   border: 0;
-  box-shadow: none;
 }
 
 input[type="file"] {


### PR DESCRIPTION
This is a bug fix.

## Summary

With `box-shadow`:

![image](https://user-images.githubusercontent.com/7273074/74134406-7cd42400-4c25-11ea-9013-ca2c3523a038.png)

Without:

![image](https://user-images.githubusercontent.com/7273074/74134450-92e1e480-4c25-11ea-85f3-7088ed7791ae.png)