### PR TITLE
fix: Do not redirect user away from site after they submit a comment

### DIFF
--- a/_includes/comments-providers/staticman_v2.html
+++ b/_includes/comments-providers/staticman_v2.html
@@ -1,4 +1,4 @@
-{% if site.repository and site.staticman.branch %}
+{% if site.repository and site.comments.staticman.branch %}
   <script>
     (function ($) {
     $('#new_comment').submit(function () {


### PR DESCRIPTION
This is a bug fix.

## Summary

This fixes the issue of the user being redirected away from the website to a JSON file after submitting a comment, rather than an alert box showing up on the page letting them know if their comment was successfully submitted or not as intended.

## Context

This bug was introduced by PR #2351 where it changed the `site.staticman.branch` variable path to `site.comments.staticman.branch` for staticman v2, but missed the naming refactor in staticman_v2.html.