### PR TITLE
Use first_page_path from Paginate V2 if available

### DIFF
--- a/_includes/paginator.html
+++ b/_includes/paginator.html
@@ -1,6 +1,6 @@
 {% if paginator.total_pages > 1 %}
 <nav class="pagination">
-  {% assign first_page_path = site.paginate_path | replace: 'page:num', '' | replace: '//', '/' | relative_url %}
+  {% assign first_page_path = paginator.first_page_path | default: site.paginate_path | replace: 'page:num', '' | replace: '//', '/' | relative_url %}
   <ul>
     {% comment %} Link for previous page {% endcomment %}
     {% if paginator.previous_page %}


### PR DESCRIPTION
This is an enhancement or feature.

Use `paginator.first_page_path` from Paginate V2 plugin for better compatibility. The original `jekyll-paginator` doesn't have this variable so this PR will not affect sites using original paginator.

I was reviewing my local overrides of the theme when I noticed this change and I even forgot what the problem was (what this change solved) but I hope this is helpful.