### PR TITLE
Clarify lunr only searches documents in collections

### DIFF
--- a/docs/_docs/05-configuration.md
+++ b/docs/_docs/05-configuration.md
@@ -374,7 +374,7 @@ repository: # GitHub username/repo-name e.g. "mmistakes/minimal-mistakes"
 **Note:** Make sure the repo is public, otherwise your readers will not be able to view the issues/comments. The [issues feature](https://guides.github.com/features/issues/) also needs to be active on your repo.
 {: .notice--warning}
 
-To enable utterances on the front end set `comments.provider` and the color theme of the widget. 
+To enable utterances on the front end set `comments.provider` and the color theme of the widget.
 
 ```yaml
 comments:
@@ -533,7 +533,7 @@ To enable site-wide search add `search: true` to your `_config.yml`.
 
 #### Lunr (default)
 
-The default search uses [**Lunr**](https://lunrjs.com/) to build a search index of all your documents. This method is 100% compatible with sites hosted on GitHub Pages.
+The default search uses [**Lunr**](https://lunrjs.com/) to build a search index of all post and your documents in collections. This method is 100% compatible with sites hosted on GitHub Pages.
 
 **Note:** Only the first 50 words of a post or page's body content is added to the Lunr search index. Setting `search_full_content` to `true` in your `_config.yml` will override this and could impact page load performance.
 {: .notice--warning}
@@ -600,13 +600,13 @@ Add a Google search box to your site.
 1. Create a **New search engine** in [Google Custom Search Engine](https://cse.google.com/cse/all), give it an appropriate name and setup "Sites to search" to your liking.
 
 2. Under **Look and feel** choose the "Results only" layout and a theme (*Minimalist* is a good choice to match the default look of the Minimal Mistakes).
-   
+
    ![Google Custom Search Engine layout]({{ '/assets/images/google-custom-search-engine-layout.png' | relative_url }})
 
 3. Select "Save & Get Code" and grab your search engine ID from the line that begins with `var cx = 'YOUR_SEARCH_ENGINE_ID'`.
 
 4. Add your search engine ID to `_config.yml` like so:
-   
+
    ```yaml
    google:
      search_engine_id: YOUR_SEARCH_ENGINE_ID
@@ -793,7 +793,7 @@ author:
   name     : "Your Name"
   avatar   : "/assets/images/bio-photo.jpg"
   bio      : "My awesome biography constrained to a sentence or two goes here."
-  location : "Somewhere, USA" 
+  location : "Somewhere, USA"
 ```
 
 Author links are all optional, include the ones you want visible under the `author.links` array.


### PR DESCRIPTION
This is a documentation change.

## Summary

Update documents to clarify Lunr only searches documents in collections or posts.

## Context

I'm newbie of jekyll and github pages, and I couldn't figure out why my pages under `/docs` directories cannot be searched for a couple of hours.
So, I think it's gonna be great if we explicit say `documents in collections` can be searched, so that newbies can understand.

###  Is this related to any GitHub issue(s)?
It looks this PR is related with https://github.com/mmistakes/minimal-mistakes/issues/1663#issuecomment-387790192