### PR TITLE
Add missing Vietnamese translations

### DIFF
--- a/_data/ui-text.yml
+++ b/_data/ui-text.yml
@@ -940,17 +940,17 @@ id-ID:
 # Vietnamese
 # ----------
 vi: &DEFAULT_VI
-  skip_links                 :
-  skip_primary_nav           :
-  skip_content               :
-  skip_footer                :
+  skip_links                 : "Đường dẫn tắt"
+  skip_primary_nav           : "Nhảy tới thanh điều hướng"
+  skip_content               : "Nhảy tới nội dung"
+  skip_footer                : "Nhảy tới chân trang"
   page                       : "Trang"
   pagination_previous        : "Trước"
   pagination_next            : "Sau"
   breadcrumb_home_label      : "Trang chủ"
   breadcrumb_separator       : "/"
   menu_label                 : "Menu"
-  search_label               :
+  search_label               : "Tìm kiếm"
   toc_label                  : "Tại trang này"
   ext_link_label             : "Đường dẫn trực tiếp"
   less_than                  : "nhỏ hơn"
@@ -982,7 +982,7 @@ vi: &DEFAULT_VI
   comment_success_msg        : "Cảm ơn bạn đã bình luận! Bình luận sẽ xuất hiện sau khi được duyệt."
   comment_error_msg          : "Rất tiếc, có lỗi trong việc gửi bình luận. Hãy đảm bảo toàn bộ các phần bắt buộc đã được điền đầy đủ và thử lại."
   loading_label              : "Đang tải..."
-  search_label_text          :
+  search_label_text          : "Nhập từ khóa cần tìm..."
   search_placeholder_text    : "Nhập từ khóa cần tìm..."
   results_found              : "Kết quả tìm được"
   back_to_top                : "Lên đầu trang"


### PR DESCRIPTION
This is an enhancement or feature.

## Summary

I've just updated some of the missing labels for Vietnamese.

## Context

This is not related to any GitHub issue(s).