### PR TITLE
Use css padding for author urls to fix underline hover state

### DIFF
--- a/_includes/author-profile.html
+++ b/_includes/author-profile.html
@@ -40,7 +40,7 @@
       {% if author.links %}
         {% for link in author.links %}
           {% if link.label and link.url %}
-            <li><a href="{{ link.url }}" rel="nofollow noopener noreferrer"><i class="{{ link.icon | default: 'fas fa-link' }}" aria-hidden="true"></i><span class="text">{{ link.label }}</span></a></li>
+            <li><a href="{{ link.url }}" rel="nofollow noopener noreferrer"><i class="{{ link.icon | default: 'fas fa-link' }}" aria-hidden="true"></i><span class="label">{{ link.label }}</span></a></li>
           {% endif %}
         {% endfor %}
       {% endif %}
@@ -48,7 +48,7 @@
       {% if author.uri %}
         <li>
           <a href="{{ author.uri }}" itemprop="url">
-            <i class="fas fa-fw fa-link" aria-hidden="true"></i><span class="text">{{ site.data.ui-text[site.locale].website_label | default: "Website" }}</span>
+            <i class="fas fa-fw fa-link" aria-hidden="true"></i><span class="label">{{ site.data.ui-text[site.locale].website_label | default: "Website" }}</span>
           </a>
         </li>
       {% endif %}
@@ -57,7 +57,7 @@
         <li>
           <a href="mailto:{{ author.email }}">
             <meta itemprop="email" content="{{ author.email }}" />
-            <i class="fas fa-fw fa-envelope-square" aria-hidden="true"></i><span class="text">{{ site.data.ui-text[site.locale].email_label | default: "Email" }}</span>
+            <i class="fas fa-fw fa-envelope-square" aria-hidden="true"></i><span class="label">{{ site.data.ui-text[site.locale].email_label | default: "Email" }}</span>
           </a>
         </li>
       {% endif %}
@@ -65,7 +65,7 @@
       {% if author.keybase %}
         <li>
           <a href="https://keybase.io/{{ author.keybase }}" itemprop="sameAs" rel="nofollow noopener noreferrer">
-            <i class="fas fa-fw fa-key" aria-hidden="true"></i><span class="text">Keybase</span>
+            <i class="fas fa-fw fa-key" aria-hidden="true"></i><span class="label">Keybase</span>
           </a>
         </li>
       {% endif %}
@@ -73,7 +73,7 @@
       {% if author.twitter %}
         <li>
           <a href="https://twitter.com/{{ author.twitter }}" itemprop="sameAs" rel="nofollow noopener noreferrer">
-            <i class="fab fa-fw fa-twitter-square" aria-hidden="true"></i><span class="text">Twitter</span>
+            <i class="fab fa-fw fa-twitter-square" aria-hidden="true"></i><span class="label">Twitter</span>
           </a>
         </li>
       {% endif %}
@@ -81,7 +81,7 @@
       {% if author.facebook %}
         <li>
           <a href="https://www.facebook.com/{{ author.facebook }}" itemprop="sameAs" rel="nofollow noopener noreferrer">
-            <i class="fab fa-fw fa-facebook-square" aria-hidden="true"></i><span class="text">Facebook</span>
+            <i class="fab fa-fw fa-facebook-square" aria-hidden="true"></i><span class="label">Facebook</span>
           </a>
         </li>
       {% endif %}
@@ -89,7 +89,7 @@
       {% if author.linkedin %}
         <li>
           <a href="https://www.linkedin.com/in/{{ author.linkedin }}" itemprop="sameAs" rel="nofollow noopener noreferrer">
-            <i class="fab fa-fw fa-linkedin" aria-hidden="true"></i><span class="text">LinkedIn</span>
+            <i class="fab fa-fw fa-linkedin" aria-hidden="true"></i><span class="label">LinkedIn</span>
           </a>
         </li>
       {% endif %}
@@ -97,7 +97,7 @@
       {% if author.xing %}
         <li>
           <a href="https://www.xing.com/profile/{{ author.xing }}" itemprop="sameAs" rel="nofollow noopener noreferrer">
-            <i class="fab fa-fw fa-xing-square" aria-hidden="true"></i><span class="text">XING</span>
+            <i class="fab fa-fw fa-xing-square" aria-hidden="true"></i><span class="label">XING</span>
           </a>
         </li>
       {% endif %}
@@ -105,7 +105,7 @@
       {% if author.instagram %}
         <li>
           <a href="https://instagram.com/{{ author.instagram }}" itemprop="sameAs" rel="nofollow noopener noreferrer">
-            <i class="fab fa-fw fa-instagram" aria-hidden="true"></i><span class="text">Instagram</span>
+            <i class="fab fa-fw fa-instagram" aria-hidden="true"></i><span class="label">Instagram</span>
           </a>
         </li>
       {% endif %}
@@ -113,7 +113,7 @@
       {% if author.tumblr %}
         <li>
           <a href="https://{{ author.tumblr }}.tumblr.com" itemprop="sameAs" rel="nofollow noopener noreferrer">
-            <i class="fab fa-fw fa-tumblr-square" aria-hidden="true"></i><span class="text">Tumblr</span>
+            <i class="fab fa-fw fa-tumblr-square" aria-hidden="true"></i><span class="label">Tumblr</span>
           </a>
         </li>
       {% endif %}
@@ -121,7 +121,7 @@
       {% if author.bitbucket %}
         <li>
           <a href="https://bitbucket.org/{{ author.bitbucket }}" itemprop="sameAs" rel="nofollow noopener noreferrer">
-            <i class="fab fa-fw fa-bitbucket" aria-hidden="true"></i><span class="text">Bitbucket</span>
+            <i class="fab fa-fw fa-bitbucket" aria-hidden="true"></i><span class="label">Bitbucket</span>
           </a>
         </li>
       {% endif %}
@@ -129,7 +129,7 @@
       {% if author.github %}
         <li>
           <a href="https://github.com/{{ author.github }}" itemprop="sameAs" rel="nofollow noopener noreferrer">
-            <i class="fab fa-fw fa-github" aria-hidden="true"></i><span class="text">GitHub</span>
+            <i class="fab fa-fw fa-github" aria-hidden="true"></i><span class="label">GitHub</span>
           </a>
         </li>
       {% endif %}
@@ -137,7 +137,7 @@
       {% if author.gitlab %}
         <li>
           <a href="https://gitlab.com/{{ author.gitlab }}" itemprop="sameAs" rel="nofollow noopener noreferrer">
-            <i class="fab fa-fw fa-gitlab" aria-hidden="true"></i><span class="text">GitLab</span>
+            <i class="fab fa-fw fa-gitlab" aria-hidden="true"></i><span class="label">GitLab</span>
           </a>
         </li>
       {% endif %}
@@ -145,7 +145,7 @@
       {% if author.stackoverflow %}
         <li>
           <a href="https://stackoverflow.com/users/{{ author.stackoverflow }}" itemprop="sameAs" rel="nofollow noopener noreferrer">
-            <i class="fab fa-fw fa-stack-overflow" aria-hidden="true"></i><span class="text">Stack Overflow</span>
+            <i class="fab fa-fw fa-stack-overflow" aria-hidden="true"></i><span class="label">Stack Overflow</span>
           </a>
         </li>
       {% endif %}
@@ -153,7 +153,7 @@
       {% if author.lastfm %}
         <li>
           <a href="https://last.fm/user/{{ author.lastfm }}" itemprop="sameAs" rel="nofollow noopener noreferrer">
-            <i class="fab fa-fw fa-lastfm-square" aria-hidden="true"></i><span class="text">Last.fm</span>
+            <i class="fab fa-fw fa-lastfm-square" aria-hidden="true"></i><span class="label">Last.fm</span>
           </a>
         </li>
       {% endif %}
@@ -161,7 +161,7 @@
       {% if author.dribbble %}
         <li>
           <a href="https://dribbble.com/{{ author.dribbble }}" itemprop="sameAs" rel="nofollow noopener noreferrer">
-            <i class="fab fa-fw fa-dribbble" aria-hidden="true"></i><span class="text">Dribbble</span>
+            <i class="fab fa-fw fa-dribbble" aria-hidden="true"></i><span class="label">Dribbble</span>
           </a>
         </li>
       {% endif %}
@@ -169,7 +169,7 @@
       {% if author.pinterest %}
         <li>
           <a href="https://www.pinterest.com/{{ author.pinterest }}" itemprop="sameAs" rel="nofollow noopener noreferrer">
-            <i class="fab fa-fw fa-pinterest" aria-hidden="true"></i><span class="text">Pinterest</span>
+            <i class="fab fa-fw fa-pinterest" aria-hidden="true"></i><span class="label">Pinterest</span>
           </a>
         </li>
       {% endif %}
@@ -177,7 +177,7 @@
       {% if author.foursquare %}
         <li>
           <a href="https://foursquare.com/{{ author.foursquare }}" itemprop="sameAs" rel="nofollow noopener noreferrer">
-            <i class="fab fa-fw fa-foursquare" aria-hidden="true"></i><span class="text">Foursquare</span>
+            <i class="fab fa-fw fa-foursquare" aria-hidden="true"></i><span class="label">Foursquare</span>
           </a>
         </li>
       {% endif %}
@@ -185,7 +185,7 @@
       {% if author.steam %}
         <li>
           <a href="https://steamcommunity.com/id/{{ author.steam }}" itemprop="sameAs" rel="nofollow noopener noreferrer">
-            <i class="fab fa-fw fa-steam" aria-hidden="true"></i><span class="text">Steam</span>
+            <i class="fab fa-fw fa-steam" aria-hidden="true"></i><span class="label">Steam</span>
           </a>
         </li>
       {% endif %}
@@ -194,13 +194,13 @@
         {% if author.youtube contains "://" %}
           <li>
             <a href="{{ author.youtube }}" itemprop="sameAs" rel="nofollow noopener noreferrer">
-              <i class="fab fa-fw fa-youtube" aria-hidden="true"></i><span class="text">YouTube</span>
+              <i class="fab fa-fw fa-youtube" aria-hidden="true"></i><span class="label">YouTube</span>
             </a>
           </li>
         {% elsif author.youtube %}
           <li>
             <a href="https://www.youtube.com/user/{{ author.youtube }}" itemprop="sameAs" rel="nofollow noopener noreferrer">
-              <i class="fab fa-fw fa-youtube" aria-hidden="true"></i><span class="text">YouTube</span>
+              <i class="fab fa-fw fa-youtube" aria-hidden="true"></i><span class="label">YouTube</span>
             </a>
           </li>
         {% endif %}
@@ -209,7 +209,7 @@
       {% if author.soundcloud %}
         <li>
           <a href="https://soundcloud.com/{{ author.soundcloud }}" itemprop="sameAs" rel="nofollow noopener noreferrer">
-            <i class="fab fa-fw fa-soundcloud" aria-hidden="true"></i><span class="text">SoundCloud</span>
+            <i class="fab fa-fw fa-soundcloud" aria-hidden="true"></i><span class="label">SoundCloud</span>
           </a>
         </li>
       {% endif %}
@@ -217,7 +217,7 @@
       {% if author.weibo %}
         <li>
           <a href="https://www.weibo.com/{{ author.weibo }}" itemprop="sameAs" rel="nofollow noopener noreferrer">
-            <i class="fab fa-fw fa-weibo" aria-hidden="true"></i><span class="text">Weibo</span>
+            <i class="fab fa-fw fa-weibo" aria-hidden="true"></i><span class="label">Weibo</span>
           </a>
         </li>
       {% endif %}
@@ -225,7 +225,7 @@
       {% if author.flickr %}
         <li>
           <a href="https://www.flickr.com/{{ author.flickr }}" itemprop="sameAs" rel="nofollow noopener noreferrer">
-            <i class="fab fa-fw fa-flickr" aria-hidden="true"></i><span class="text">Flickr</span>
+            <i class="fab fa-fw fa-flickr" aria-hidden="true"></i><span class="label">Flickr</span>
           </a>
         </li>
       {% endif %}
@@ -233,7 +233,7 @@
       {% if author.codepen %}
         <li>
           <a href="https://codepen.io/{{ author.codepen }}" itemprop="sameAs" rel="nofollow noopener noreferrer">
-            <i class="fab fa-fw fa-codepen" aria-hidden="true"></i><span class="text">CodePen</span>
+            <i class="fab fa-fw fa-codepen" aria-hidden="true"></i><span class="label">CodePen</span>
           </a>
         </li>
       {% endif %}
@@ -241,7 +241,7 @@
       {% if author.vine %}
         <li>
           <a href="https://vine.co/u/{{ author.vine }}" itemprop="sameAs" rel="nofollow noopener noreferrer">
-            <i class="fab fa-fw fa-vine" aria-hidden="true"></i><span class="text">{{ site.data.ui-text[site.locale].email_label | default: "Email" }}</span>
+            <i class="fab fa-fw fa-vine" aria-hidden="true"></i><span class="label">{{ site.data.ui-text[site.locale].email_label | default: "Email" }}</span>
           </a>
         </li>
       {% endif %}

--- a/_includes/author-profile.html
+++ b/_includes/author-profile.html
@@ -40,7 +40,7 @@
       {% if author.links %}
         {% for link in author.links %}
           {% if link.label and link.url %}
-            <li><a href="{{ link.url }}" rel="nofollow noopener noreferrer"><i class="{{ link.icon | default: 'fas fa-link' }}" aria-hidden="true"></i> {{ link.label }}</a></li>
+            <li><a href="{{ link.url }}" rel="nofollow noopener noreferrer"><i class="{{ link.icon | default: 'fas fa-link' }}" aria-hidden="true"></i><span class="text">{{ link.label }}</span></a></li>
           {% endif %}
         {% endfor %}
       {% endif %}
@@ -48,7 +48,7 @@
       {% if author.uri %}
         <li>
           <a href="{{ author.uri }}" itemprop="url">
-            <i class="fas fa-fw fa-link" aria-hidden="true"></i> {{ site.data.ui-text[site.locale].website_label | default: "Website" }}
+            <i class="fas fa-fw fa-link" aria-hidden="true"></i><span class="text">{{ site.data.ui-text[site.locale].website_label | default: "Website" }}</span>
           </a>
         </li>
       {% endif %}
@@ -57,7 +57,7 @@
         <li>
           <a href="mailto:{{ author.email }}">
             <meta itemprop="email" content="{{ author.email }}" />
-            <i class="fas fa-fw fa-envelope-square" aria-hidden="true"></i> {{ site.data.ui-text[site.locale].email_label | default: "Email" }}
+            <i class="fas fa-fw fa-envelope-square" aria-hidden="true"></i><span class="text">{{ site.data.ui-text[site.locale].email_label | default: "Email" }}</span>
           </a>
         </li>
       {% endif %}
@@ -65,7 +65,7 @@
       {% if author.keybase %}
         <li>
           <a href="https://keybase.io/{{ author.keybase }}" itemprop="sameAs" rel="nofollow noopener noreferrer">
-            <i class="fas fa-fw fa-key" aria-hidden="true"></i> Keybase
+            <i class="fas fa-fw fa-key" aria-hidden="true"></i><span class="text">Keybase</span>
           </a>
         </li>
       {% endif %}
@@ -73,7 +73,7 @@
       {% if author.twitter %}
         <li>
           <a href="https://twitter.com/{{ author.twitter }}" itemprop="sameAs" rel="nofollow noopener noreferrer">
-            <i class="fab fa-fw fa-twitter-square" aria-hidden="true"></i> Twitter
+            <i class="fab fa-fw fa-twitter-square" aria-hidden="true"></i><span class="text">Twitter</span>
           </a>
         </li>
       {% endif %}
@@ -81,7 +81,7 @@
       {% if author.facebook %}
         <li>
           <a href="https://www.facebook.com/{{ author.facebook }}" itemprop="sameAs" rel="nofollow noopener noreferrer">
-            <i class="fab fa-fw fa-facebook-square" aria-hidden="true"></i> Facebook
+            <i class="fab fa-fw fa-facebook-square" aria-hidden="true"></i><span class="text">Facebook</span>
           </a>
         </li>
       {% endif %}
@@ -89,7 +89,7 @@
       {% if author.linkedin %}
         <li>
           <a href="https://www.linkedin.com/in/{{ author.linkedin }}" itemprop="sameAs" rel="nofollow noopener noreferrer">
-            <i class="fab fa-fw fa-linkedin" aria-hidden="true"></i> LinkedIn
+            <i class="fab fa-fw fa-linkedin" aria-hidden="true"></i><span class="text">LinkedIn</span>
           </a>
         </li>
       {% endif %}
@@ -97,7 +97,7 @@
       {% if author.xing %}
         <li>
           <a href="https://www.xing.com/profile/{{ author.xing }}" itemprop="sameAs" rel="nofollow noopener noreferrer">
-            <i class="fab fa-fw fa-xing-square" aria-hidden="true"></i> XING
+            <i class="fab fa-fw fa-xing-square" aria-hidden="true"></i><span class="text">XING</span>
           </a>
         </li>
       {% endif %}
@@ -105,7 +105,7 @@
       {% if author.instagram %}
         <li>
           <a href="https://instagram.com/{{ author.instagram }}" itemprop="sameAs" rel="nofollow noopener noreferrer">
-            <i class="fab fa-fw fa-instagram" aria-hidden="true"></i> Instagram
+            <i class="fab fa-fw fa-instagram" aria-hidden="true"></i><span class="text">Instagram</span>
           </a>
         </li>
       {% endif %}
@@ -113,7 +113,7 @@
       {% if author.tumblr %}
         <li>
           <a href="https://{{ author.tumblr }}.tumblr.com" itemprop="sameAs" rel="nofollow noopener noreferrer">
-            <i class="fab fa-fw fa-tumblr-square" aria-hidden="true"></i> Tumblr
+            <i class="fab fa-fw fa-tumblr-square" aria-hidden="true"></i><span class="text">Tumblr</span>
           </a>
         </li>
       {% endif %}
@@ -121,7 +121,7 @@
       {% if author.bitbucket %}
         <li>
           <a href="https://bitbucket.org/{{ author.bitbucket }}" itemprop="sameAs" rel="nofollow noopener noreferrer">
-            <i class="fab fa-fw fa-bitbucket" aria-hidden="true"></i> Bitbucket
+            <i class="fab fa-fw fa-bitbucket" aria-hidden="true"></i><span class="text">Bitbucket</span>
           </a>
         </li>
       {% endif %}
@@ -129,7 +129,7 @@
       {% if author.github %}
         <li>
           <a href="https://github.com/{{ author.github }}" itemprop="sameAs" rel="nofollow noopener noreferrer">
-            <i class="fab fa-fw fa-github" aria-hidden="true"></i> GitHub
+            <i class="fab fa-fw fa-github" aria-hidden="true"></i><span class="text">GitHub</span>
           </a>
         </li>
       {% endif %}
@@ -137,7 +137,7 @@
       {% if author.gitlab %}
         <li>
           <a href="https://gitlab.com/{{ author.gitlab }}" itemprop="sameAs" rel="nofollow noopener noreferrer">
-            <i class="fab fa-fw fa-gitlab" aria-hidden="true"></i> GitLab
+            <i class="fab fa-fw fa-gitlab" aria-hidden="true"></i><span class="text">GitLab</span>
           </a>
         </li>
       {% endif %}
@@ -145,7 +145,7 @@
       {% if author.stackoverflow %}
         <li>
           <a href="https://stackoverflow.com/users/{{ author.stackoverflow }}" itemprop="sameAs" rel="nofollow noopener noreferrer">
-            <i class="fab fa-fw fa-stack-overflow" aria-hidden="true"></i> Stack Overflow
+            <i class="fab fa-fw fa-stack-overflow" aria-hidden="true"></i><span class="text">Stack Overflow</span>
           </a>
         </li>
       {% endif %}
@@ -153,7 +153,7 @@
       {% if author.lastfm %}
         <li>
           <a href="https://last.fm/user/{{ author.lastfm }}" itemprop="sameAs" rel="nofollow noopener noreferrer">
-            <i class="fab fa-fw fa-lastfm-square" aria-hidden="true"></i> Last.fm
+            <i class="fab fa-fw fa-lastfm-square" aria-hidden="true"></i><span class="text">Last.fm</span>
           </a>
         </li>
       {% endif %}
@@ -161,7 +161,7 @@
       {% if author.dribbble %}
         <li>
           <a href="https://dribbble.com/{{ author.dribbble }}" itemprop="sameAs" rel="nofollow noopener noreferrer">
-            <i class="fab fa-fw fa-dribbble" aria-hidden="true"></i> Dribbble
+            <i class="fab fa-fw fa-dribbble" aria-hidden="true"></i><span class="text">Dribbble</span>
           </a>
         </li>
       {% endif %}
@@ -169,7 +169,7 @@
       {% if author.pinterest %}
         <li>
           <a href="https://www.pinterest.com/{{ author.pinterest }}" itemprop="sameAs" rel="nofollow noopener noreferrer">
-            <i class="fab fa-fw fa-pinterest" aria-hidden="true"></i> Pinterest
+            <i class="fab fa-fw fa-pinterest" aria-hidden="true"></i><span class="text">Pinterest</span>
           </a>
         </li>
       {% endif %}
@@ -177,7 +177,7 @@
       {% if author.foursquare %}
         <li>
           <a href="https://foursquare.com/{{ author.foursquare }}" itemprop="sameAs" rel="nofollow noopener noreferrer">
-            <i class="fab fa-fw fa-foursquare" aria-hidden="true"></i> Foursquare
+            <i class="fab fa-fw fa-foursquare" aria-hidden="true"></i><span class="text">Foursquare</span>
           </a>
         </li>
       {% endif %}
@@ -185,7 +185,7 @@
       {% if author.steam %}
         <li>
           <a href="https://steamcommunity.com/id/{{ author.steam }}" itemprop="sameAs" rel="nofollow noopener noreferrer">
-            <i class="fab fa-fw fa-steam" aria-hidden="true"></i> Steam
+            <i class="fab fa-fw fa-steam" aria-hidden="true"></i><span class="text">Steam</span>
           </a>
         </li>
       {% endif %}
@@ -194,13 +194,13 @@
         {% if author.youtube contains "://" %}
           <li>
             <a href="{{ author.youtube }}" itemprop="sameAs" rel="nofollow noopener noreferrer">
-              <i class="fab fa-fw fa-youtube" aria-hidden="true"></i> YouTube
+              <i class="fab fa-fw fa-youtube" aria-hidden="true"></i><span class="text">YouTube</span>
             </a>
           </li>
         {% elsif author.youtube %}
           <li>
             <a href="https://www.youtube.com/user/{{ author.youtube }}" itemprop="sameAs" rel="nofollow noopener noreferrer">
-              <i class="fab fa-fw fa-youtube" aria-hidden="true"></i> YouTube
+              <i class="fab fa-fw fa-youtube" aria-hidden="true"></i><span class="text">YouTube</span>
             </a>
           </li>
         {% endif %}
@@ -209,7 +209,7 @@
       {% if author.soundcloud %}
         <li>
           <a href="https://soundcloud.com/{{ author.soundcloud }}" itemprop="sameAs" rel="nofollow noopener noreferrer">
-            <i class="fab fa-fw fa-soundcloud" aria-hidden="true"></i> SoundCloud
+            <i class="fab fa-fw fa-soundcloud" aria-hidden="true"></i><span class="text">SoundCloud</span>
           </a>
         </li>
       {% endif %}
@@ -217,7 +217,7 @@
       {% if author.weibo %}
         <li>
           <a href="https://www.weibo.com/{{ author.weibo }}" itemprop="sameAs" rel="nofollow noopener noreferrer">
-            <i class="fab fa-fw fa-weibo" aria-hidden="true"></i> Weibo
+            <i class="fab fa-fw fa-weibo" aria-hidden="true"></i><span class="text">Weibo</span>
           </a>
         </li>
       {% endif %}
@@ -225,7 +225,7 @@
       {% if author.flickr %}
         <li>
           <a href="https://www.flickr.com/{{ author.flickr }}" itemprop="sameAs" rel="nofollow noopener noreferrer">
-            <i class="fab fa-fw fa-flickr" aria-hidden="true"></i> Flickr
+            <i class="fab fa-fw fa-flickr" aria-hidden="true"></i><span class="text">Flickr</span>
           </a>
         </li>
       {% endif %}
@@ -233,7 +233,7 @@
       {% if author.codepen %}
         <li>
           <a href="https://codepen.io/{{ author.codepen }}" itemprop="sameAs" rel="nofollow noopener noreferrer">
-            <i class="fab fa-fw fa-codepen" aria-hidden="true"></i> CodePen
+            <i class="fab fa-fw fa-codepen" aria-hidden="true"></i><span class="text">CodePen</span>
           </a>
         </li>
       {% endif %}
@@ -241,7 +241,7 @@
       {% if author.vine %}
         <li>
           <a href="https://vine.co/u/{{ author.vine }}" itemprop="sameAs" rel="nofollow noopener noreferrer">
-            <i class="fab fa-fw fa-vine" aria-hidden="true"></i> Vine
+            <i class="fab fa-fw fa-vine" aria-hidden="true"></i><span class="text">{{ site.data.ui-text[site.locale].email_label | default: "Email" }}</span>
           </a>
         </li>
       {% endif %}

--- a/_sass/minimal-mistakes/_sidebar.scss
+++ b/_sass/minimal-mistakes/_sidebar.scss
@@ -195,7 +195,7 @@
   }
 
   .author__urls {
-    span.text {
+    span.label {
       padding-left: 5px;
     }
   }

--- a/_sass/minimal-mistakes/_sidebar.scss
+++ b/_sass/minimal-mistakes/_sidebar.scss
@@ -194,6 +194,12 @@
     }
   }
 
+  .author__urls {
+    span.text {
+      padding-left: 5px;
+    }
+  }
+
   @include breakpoint($large) {
     display: block;
   }


### PR DESCRIPTION
**This is a bug (style) fix.**

## Summary
Author profile page uses a literal ` ` space character as padding between the social icon and the text. Which as a result causes the underline to show up on a blank space character on hover, causing it to look like the example below.

This PR wraps the text with a `span` block that can be used to customize spacing between the social icon and its relevant text, making it a breeze to customize as opposed to copying `author-profile.html` to your local repo and customizing it just to fix spacing, making upgrading the theme very difficult.


### [About page - BUG](https://mmistakes.github.io/minimal-mistakes/about/)
![image](https://user-images.githubusercontent.com/25732808/77850248-2738e400-719f-11ea-8ac1-2633923d51d8.png)

### With fixed spacing
![image](https://user-images.githubusercontent.com/25732808/77850254-36b82d00-719f-11ea-9c16-7400f1c8ad65.png)
