### PR TITLE
Added the possibility to avoid the recent posts heading in home

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -27,6 +27,7 @@ repository               : # GitHub username/repo-name e.g. "mmistakes/minimal-m
 teaser                   : # path of fallback teaser image, e.g. "/assets/images/500x300.png"
 logo                     : # path of logo image to display in the masthead, e.g. "/assets/images/88x88.png"
 masthead_title           : # overrides the website title displayed in the masthead, use " " for no title
+recent_posts_title_off   : # true, false (default)
 # breadcrumbs            : false # true, false (default)
 words_per_minute         : 200
 comments:

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -4,7 +4,9 @@ layout: archive
 
 {{ content }}
 
+{% unless site.recent_posts_title_off %}
 <h3 class="archive__subtitle">{{ site.data.ui-text[site.locale].recent_posts | default: "Recent Posts" }}</h3>
+{% endunless %}
 
 {% if paginator %}
   {% assign posts = paginator.posts %}

--- a/docs/_docs/10-layouts.md
+++ b/docs/_docs/10-layouts.md
@@ -337,6 +337,12 @@ paginate_path: /blog/page:num
 **Note:** Jekyll can only paginate a single `index.html` file. If you'd like to paginate more pages (e.g. category indexes) you'll need the help of a custom plugin. For more pagination related settings check the [**Configuration**]({{ "/docs/configuration/#paginate" | relative_url }}) section.
 {: .notice--info}
 
+To avoid the "recent posts" heading, set to `true` the `recent_posts_title_off` in **_config.yml**.
+
+```yaml
+recent_posts_title_off: true
+```
+
 ## Splash page layout
 
 For full-width landing pages that need a little something extra add `layout: splash` to the YAML Front Matter.


### PR DESCRIPTION
This is an enhancement or feature.

## Summary

<!--
  Provide a description of what your pull request changes.
-->

The `home` page layout is built to show a list of recent posts after the **recent posts** heading (`<h3>`):

<img width="676" alt="Screen Shot 2020-03-29 at 11 53 57 PM" src="https://user-images.githubusercontent.com/8323664/77861963-a5859c80-7218-11ea-81af-6f1f9e96cdab.png">

However, it should be convenient to have the configuration option to disable the **recent posts** heading because home pages in many blogs usually don't have such heading and start directly with the content (i.e., blog posts).

This PR includes the new configuration parameter `recent_posts_title_off` in **_config.yml**, that is set to `false` by default (if it is set to `true`, the heading is not displayed), the conditional check in the `home` layout (**home.html**) and the updated documentation.
