### PR TITLE
Fix #2478 "Follow menu falls under post links"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 - Clarify documentation that Lunr only searches documents in collections. [#2450](https://github.com/mmistakes/minimal-mistakes/pull/2450)
 - Add guide on applying Front Matter defaults to jekyll-archives pages [#2466](https://github.com/mmistakes/minimal-mistakes/pull/2466)
 
+### Bug Fixes
+
+- Fix "Follow menu falls under post links" on small screens. [#2479](https://github.com/mmistakes/minimal-mistakes/issues/2479)
+
 ## [4.19.1](https://github.com/mmistakes/minimal-mistakes/releases/tag/4.19.1)
 
 ### Enhancements

--- a/_sass/minimal-mistakes/_archive.scss
+++ b/_sass/minimal-mistakes/_archive.scss
@@ -23,7 +23,7 @@
 
   a {
     position: relative;
-    z-index: 10;
+    z-index: 5;
   }
 
   a[rel="permalink"] {

--- a/_sass/minimal-mistakes/_archive.scss
+++ b/_sass/minimal-mistakes/_archive.scss
@@ -23,7 +23,7 @@
 
   a {
     position: relative;
-    z-index: 5;
+    z-index: 10;
   }
 
   a[rel="permalink"] {

--- a/_sass/minimal-mistakes/_sidebar.scss
+++ b/_sass/minimal-mistakes/_sidebar.scss
@@ -184,7 +184,7 @@
   display: table-cell;
   vertical-align: middle;
   font-family: $sans-serif;
-  z-index: 10;
+  z-index: 20;
   position: relative;
   cursor: pointer;
 

--- a/docs/_docs/18-history.md
+++ b/docs/_docs/18-history.md
@@ -20,6 +20,10 @@ toc: false
 - Clarify documentation that Lunr only searches documents in collections. [#2450](https://github.com/mmistakes/minimal-mistakes/pull/2450)
 - Add guide on applying Front Matter defaults to jekyll-archives pages [#2466](https://github.com/mmistakes/minimal-mistakes/pull/2466)
 
+### Bug Fixes
+
+- Fix "Follow menu falls under post links" on small screens. [#2479](https://github.com/mmistakes/minimal-mistakes/issues/2479)
+
 ## [4.19.1](https://github.com/mmistakes/minimal-mistakes/releases/tag/4.19.1)
 
 ### Enhancements


### PR DESCRIPTION
This is a bug fix.

See #2478.