### PR TITLE
Hide index page from page-archive, resolves #2481

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Bug Fixes
 
 - Fix "Follow menu falls under post links" on small screens. [#2479](https://github.com/mmistakes/minimal-mistakes/issues/2479)
+- Hide index page from page-archive. [#2482](https://github.com/mmistakes/minimal-mistakes/pull/2482)
 
 ## [4.19.1](https://github.com/mmistakes/minimal-mistakes/releases/tag/4.19.1)
 

--- a/docs/_docs/18-history.md
+++ b/docs/_docs/18-history.md
@@ -23,6 +23,7 @@ toc: false
 ### Bug Fixes
 
 - Fix "Follow menu falls under post links" on small screens. [#2479](https://github.com/mmistakes/minimal-mistakes/issues/2479)
+- Hide index page from page-archive. [#2482](https://github.com/mmistakes/minimal-mistakes/pull/2482)
 
 ## [4.19.1](https://github.com/mmistakes/minimal-mistakes/releases/tag/4.19.1)
 

--- a/docs/_pages/home.md
+++ b/docs/_pages/home.md
@@ -1,6 +1,7 @@
 ---
 layout: splash
 permalink: /
+hidden: true
 header:
   overlay_color: "#5e616c"
   overlay_image: /assets/images/mm-home-page-feature.jpg

--- a/docs/_pages/page-archive.html
+++ b/docs/_pages/page-archive.html
@@ -6,5 +6,7 @@ author_profile: false
 ---
 
 {% for post in site.pages %}
-  {% include archive-single.html %}
+  {% unless post.hidden %}
+    {% include archive-single.html %}
+  {% endunless %}
 {% endfor %}


### PR DESCRIPTION
This is a bug fix.  
This is a documentation change.

## Summary

#2481 is a really interesting finding, and I would doubt anyone wants the index page listed in the archive (at least not for this theme).

This fix basically reuses the idea from #2345.