### PR TITLE
Make sticky sidebar live well with short content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+### Enhancements
+
+- Make sticky sidebar live well with short content. [#2514](https://github.com/mmistakes/minimal-mistakes/pull/2514)
+
 ## [4.19.2](https://github.com/mmistakes/minimal-mistakes/releases/tag/4.19.2)
 
 ### Enhancements

--- a/_sass/minimal-mistakes/_sidebar.scss
+++ b/_sass/minimal-mistakes/_sidebar.scss
@@ -32,7 +32,7 @@
       /* calculate height of nav list
          viewport height - nav height - masthead x-padding
       */
-      height: calc(100vh - #{$nav-height} - 2em);
+      max-height: calc(100vh - #{$nav-height} - 2em);
     }
   }
 

--- a/docs/_docs/18-history.md
+++ b/docs/_docs/18-history.md
@@ -5,9 +5,15 @@ permalink: /docs/history/
 excerpt: "Change log of enhancements and bug fixes made to the theme."
 sidebar:
   nav: docs
-last_modified_at: 2020-05-01T11:53:42-04:00
+last_modified_at: 2020-05-02T00:54:04+08:00
 toc: false
 ---
+
+## Unreleased
+
+### Enhancements
+
+- Make sticky sidebar live well with short content. [#2514](https://github.com/mmistakes/minimal-mistakes/pull/2514)
 
 ## [4.19.2](https://github.com/mmistakes/minimal-mistakes/releases/tag/4.19.2)
 


### PR DESCRIPTION
This is an enhancement or feature.

Currently, with sticky (left) sidebar enabled, the footer is pushed down beyond the first screen plus the height of the header area, which may be visually unintuitive. This PR changes the forced `height` into `max-height` for a better look in this case.

- **Before**: [image](https://user-images.githubusercontent.com/7273074/80823984-2668f700-8c10-11ea-9f74-eefb81b5e6f4.png) (Look! Scrollbar!)
- **After**: [image](https://user-images.githubusercontent.com/7273074/80823854-eb66c380-8c0f-11ea-80b9-7ea677ac37a6.png) (Note: No scrollbar on the right)

Tested with Chrome 81 (Windows 10 & macOS Catalina), Firefox 74, and Edge 44. [Here](https://ibugone.com/status/)'s a live page on my website with this patch included.