### PR TITLE
Added meta keywords section to leverage the current page tags

### DIFF
--- a/_includes/seo.html
+++ b/_includes/seo.html
@@ -64,6 +64,11 @@
   <meta property="og:description" content="{{ seo_description }}">
 {% endif %}
 
+{% if page.tags[0] %}
+{% assign comma_tags = page.tags | join: ", " %}
+  <meta property="keywords" content="{{ comma_tags | downcase }}">
+{% endif %}
+
 {% if page_large_image %}
   <meta property="og:image" content="{{ page_large_image }}">
 {% elsif page_teaser_image %}


### PR DESCRIPTION
This is an enhancement or feature.

## Summary

Add `meta` keywords section into `seo.html` leveraging the current page tags.

I wanted to add this feature in to have the option for meta keywords, right now this option is enabled by default if there are any tags for the current page. In the future we could turn this off, but I don't see much reason to since it shouldn't harm anything.

## Context

This is not related to any issue, this is a feature I've added in my own personal blog.

A working version if you would like to see can be found here - https://blog.dzielinski.dev/