### PR TITLE
Strip trailing whitespace in seo_description

### DIFF
--- a/_includes/seo.html
+++ b/_includes/seo.html
@@ -22,7 +22,7 @@
 
 {%- assign seo_description = page.description | default: page.excerpt | default: site.description -%}
 {%- if seo_description -%}
-  {%- assign seo_description = seo_description | markdownify | strip_html | newline_to_br | strip_newlines | replace: '<br />', ' ' | escape_once -%}
+  {%- assign seo_description = seo_description | markdownify | strip_html | newline_to_br | strip_newlines | replace: '<br />', ' ' | escape_once | strip -%}
 {%- endif -%}
 
 {%- assign author = page.author | default: page.authors[0] | default: site.author -%}


### PR DESCRIPTION
Related to #2541 . This will strip the extra whitespace in the end of seo_description.
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - Read the contributing document at https://github.com/mmistakes/minimal-mistakes#contributing
-->

<!--
  Choose one of the following by uncommenting it:
-->

<!-- This is a bug fix. -->
<!-- This is an enhancement or feature. -->
<!-- This is a documentation change. -->

## Summary

<!--
  Provide a description of what your pull request changes.
-->

## Context

<!--
  Is this related to any GitHub issue(s)?
-->