### PR TITLE
Add podcast to author profile

### DIFF
--- a/_includes/author-profile.html
+++ b/_includes/author-profile.html
@@ -53,6 +53,14 @@
         </li>
       {% endif %}
 
+      {% if author.podcast %}
+        <li>
+          <a href="{{ author.podcast }}" itemprop="url">
+            <i class="fas fa-podcast" aria-hidden="true"></i><span class="label">{{ site.data.ui-text[site.locale].website_label | default: "Podcast" }}</span>
+          </a>
+        </li>
+      {% endif %}
+
       {% if author.email %}
         <li>
           <a href="mailto:{{ author.email }}">


### PR DESCRIPTION
This is an enhancement or feature.

## Summary

There are links for specific services, but not for a generic podcast.  I realize there is a desire to not support every service possible, but this list of specifics is missing some generics that seem useful

## Context

n/a