### PR TITLE
Ignore teaser headline in table of contents

### DIFF
--- a/_includes/archive-single.html
+++ b/_includes/archive-single.html
@@ -17,7 +17,7 @@
         <img src="{{ teaser | relative_url }}" alt="">
       </div>
     {% endif %}
-    <h2 class="archive__item-title" itemprop="headline">
+    <h2 class="archive__item-title no_toc" itemprop="headline">
       {% if post.link %}
         <a href="{{ post.link }}">{{ title }}</a> <a href="{{ post.url | relative_url }}" rel="permalink"><i class="fas fa-link" aria-hidden="true" title="permalink"></i><span class="sr-only">Permalink</span></a>
       {% else %}


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - Read the contributing document at https://github.com/mmistakes/minimal-mistakes#contributing
-->
If you use archive-single.html on e.g. a single page, then the TOC will break. One solution is to no include the H2 deliverede by archive-single.html in the TOC.

<!--
  Choose one of the following by uncommenting it:
-->

This is a bug fix.
<!-- This is an enhancement or feature. -->
<!-- This is a documentation change. -->

## Summary

<!--
  Provide a description of what your pull request changes.
-->

When using this to include posts in another post:

```
{% assign site_posts = site.routes | where: "tags", "børnevenlig" | sort: "title" %}

{% if site_posts.size > 0 %}
  {% for post in site_posts %}
    {% include archive-single.html %}
  {% endfor %}
{% endif %}
```
I end up with this TOC:

![Screenshot (27)](https://user-images.githubusercontent.com/148026/84034193-4bcceb80-a99a-11ea-8c15-7016c6f09ff4.png)

## Context

<!--
  Is this related to any GitHub issue(s)?
-->