### PR TITLE
Load Font Awesome CSS from jsDelivr CDN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+### Enhancements
+
+- Replace Font Awesome Kits with CSS from jsDelivr CDN. [#2583](https://github.com/mmistakes/minimal-mistakes/pull/2583)
+
 ## [4.19.3](https://github.com/mmistakes/minimal-mistakes/releases/tag/4.19.3)
 
 ### Enhancements

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -13,6 +13,7 @@
 
 <!-- For all browsers -->
 <link rel="stylesheet" href="{{ '/assets/css/main.css' | relative_url }}">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@5/css/all.min.css">
 
 <!--[if IE]>
   <style>

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -4,7 +4,6 @@
   {% endfor %}
 {% else %}
   <script src="{{ '/assets/js/main.min.js' | relative_url }}"></script>
-  <script src="https://kit.fontawesome.com/4eee35f757.js"></script>
 {% endif %}
 
 {% if site.search == true or page.layout == "search" %}

--- a/docs/_docs/18-history.md
+++ b/docs/_docs/18-history.md
@@ -5,9 +5,15 @@ permalink: /docs/history/
 excerpt: "Change log of enhancements and bug fixes made to the theme."
 sidebar:
   nav: docs
-last_modified_at: 2020-06-06T11:48:13-04:00
+last_modified_at: 2020-07-02T19:28:35+08:00
 toc: false
 ---
+
+## Unreleased
+
+### Enhancements
+
+- Replace Font Awesome Kits with CSS from jsDelivr CDN. [#2583](https://github.com/mmistakes/minimal-mistakes/pull/2583)
 
 ## [4.19.3](https://github.com/mmistakes/minimal-mistakes/releases/tag/4.19.3)
 


### PR DESCRIPTION
This is an enhancement or feature.

## Summary

Instead of using Font Awesome Kits, load its CSS from [jsDelivr CDN][1].

### Why?

✔ Font Awesome official source and NPM package
✔ Always up-to-date with latest FA 5 icon sets
✔ Faster everywhere (jsDelivr is the largest public NPM CDN, also works in China)
✔ Loads fewer bytes
✔ No bothering with `async` and/or `defer`. Always loaded asynchronously and displayed as soon as it's ready
✔ Works with ads blocker
✔ Works even with JavaScript disabled

## Context

Potentially related: #413

  [1]: https://www.jsdelivr.com/package/npm/@fortawesome/fontawesome-free