### PR TITLE
Give H4 in notice some space from below

### DIFF
--- a/_sass/minimal-mistakes/_notices.scss
+++ b/_sass/minimal-mistakes/_notices.scss
@@ -23,6 +23,7 @@
 
   h4 {
     margin-top: 0 !important; /* override*/
+		line-height: inherit;
     margin-bottom: 0.75em;
   }
 


### PR DESCRIPTION
This is an enhancement or feature.

## Summary

In notice blocks, H4 elements appear too close to the following paragraph. This PR remediates that by adding `line-height: inherit` to those H4s.

It's probably too minor a change, but if you examine closely, the vertical space between the H4 and the next paragraph is even shorter than that between the two lines of the paragraph.

Before:

![image](https://user-images.githubusercontent.com/7273074/87340718-0d1ee800-c57b-11ea-8596-5432fb0a5d5f.png)

After:

![image](https://user-images.githubusercontent.com/7273074/87340747-160fb980-c57b-11ea-8c2e-4fe9dec6dbd1.png)

## Context

None