### PR TITLE
Fix "analytics.provider" config comment to list all analytics providers.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -85,7 +85,7 @@ social:
 
 # Analytics
 analytics:
-  provider               : false # false (default), "google", "google-universal", "custom"
+  provider               : false # false (default), "google", "google-universal", "google-gtag", "custom"
   google:
     tracking_id          :
     anonymize_ip         : # true, false (default)

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -81,7 +81,7 @@ social:
 
 # Analytics
 analytics:
-  provider               : "google-universal" # false (default), "google", "google-universal", "custom"
+  provider               : "google-universal" # false (default), "google", "google-universal", "google-gtag", "custom"
   google:
     tracking_id          : "UA-2011187-3" # Replace this with your ID, or delete
     anonymize_ip         : true

--- a/test/_config.yml
+++ b/test/_config.yml
@@ -75,7 +75,7 @@ social:
 
 # Analytics
 analytics:
-  provider               : false # false (default), "google", "google-universal", "custom"
+  provider               : false # false (default), "google", "google-universal", "google-gtag", "custom"
   google:
     tracking_id          :
 


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - Read the contributing document at https://github.com/mmistakes/minimal-mistakes#contributing
-->

<!--
  Choose one of the following by uncommenting it:
-->

<!-- This is a bug fix. -->
<!-- This is an enhancement or feature. -->
This is a documentation change.

## Summary

The comment provided in `_config.yml` for `analytics.provider` is not complete (missing google-gtag).

The main config's `analytics.provider` comment was properly amended by the google-gtag feature commit (79d0b75683a4c13787b117e9e612073586fa21be), but the comment was reverted, possibly by bad merge, with an unrelated commit (bac26e96b21f846df6ede382e8c7ee4019564eab) two days later.

The docs and test configs appear to have never received the initial google-gtag update.

This change fixes all three configs' `analytics.provider` comments.

<!--
  Provide a description of what your pull request changes.
-->

## Context

Comments are good.

<!--
  Is this related to any GitHub issue(s)?
-->