### PR TITLE
Change tab indent to space for consistency

### DIFF
--- a/_sass/minimal-mistakes/_notices.scss
+++ b/_sass/minimal-mistakes/_notices.scss
@@ -23,8 +23,8 @@
 
   h4 {
     margin-top: 0 !important; /* override*/
-		line-height: inherit;
     margin-bottom: 0.75em;
+    line-height: inherit;
   }
 
   @at-root .page__content #{&} h4 {


### PR DESCRIPTION
This is a bug fix.

I'm sorry for having to submit this "redundant" PR. I didn't notice I had set `autocmd FileType scss set noexpandtab` in my editor config, so that PR (#2602) had some inconsistencies w.r.t. indentation styling.

This PR changes the "faulty" tab indentation into spaces. I also moved `line-height` to below `margin-bottom` so it looks better, as similar items are grouped together.

Probably too minor to worth a separate line in the changelog, though, as this *should have been* done in 2602, instead of in this separate PR.

## Context

2602: <https://github.com/mmistakes/minimal-mistakes/pull/2602/files>