### PR TITLE
Configure entries layout `list` or `grid`

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -12,15 +12,10 @@ layout: archive
   {% assign posts = site.posts %}
 {% endif %}
 
-{% if page.entries_layout == "grid" %}
-<p></p>
-{% endif %}
-
 <div class="entries-{{ page.entries_layout | default: 'list' }}">
   {% for post in posts %}
     {% include archive-single.html type=page.entries_layout %}
   {% endfor %}
 </div>
-
 
 {% include paginator.html %}

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -17,9 +17,9 @@ layout: archive
 {% endif %}
 
 <div class="entries-{{ page.entries_layout | default: 'list' }}">
-{% for post in posts %}
-{% include archive-single.html type=page.entries_layout %}
-{% endfor %}
+  {% for post in posts %}
+    {% include archive-single.html type=page.entries_layout %}
+  {% endfor %}
 </div>
 
 

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -12,8 +12,15 @@ layout: archive
   {% assign posts = site.posts %}
 {% endif %}
 
+{% if page.entries_layout == "grid" %}
+<p></p>
+{% endif %}
+
+<div class="entries-{{ page.entries_layout | default: 'list' }}">
 {% for post in posts %}
-  {% include archive-single.html %}
+{% include archive-single.html type=page.entries_layout %}
 {% endfor %}
+</div>
+
 
 {% include paginator.html %}

--- a/_sass/minimal-mistakes/_archive.scss
+++ b/_sass/minimal-mistakes/_archive.scss
@@ -32,7 +32,7 @@
 }
 
 .archive__subtitle {
-  margin: 1.414em 0 0;
+  margin: 1.414em 0 0.5em;
   padding-bottom: 0.5em;
   font-size: $type-size-5;
   color: $muted-text-color;


### PR DESCRIPTION
This is an enhancement or feature. 

## Summary

This allows to use grid layout on `page.entries_layout` on the home layout.

## Context
There is support for layout grid on most places but home page.

I mimicked how it's done on posts/categories/tags to allow that on home page. See demo at www.cornerinthemiddle.com

Included a break since when using grid the post images are too close to the horizontal line bellow `posts` text.

There's a entries div now surrounding the posts since the first row of the grid was having a slight padding on the left. The home now behaves like posts/categories/tags pages with grid but including the paginator.

Tested on mobile renders ok and on hd desktop, for best results on desktop we can use `classes: wide` and `paginate: 4` on `_config.yml` (or multiples of 4 if you want more rows)
