### PR TITLE
Use layout: none instead of null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add `relative_url` filter to author home link [#2575](https://github.com/mmistakes/minimal-mistakes/pull/2575)
 - Fix `analytics.provider` config comment to list all analytics providers. [#2607](https://github.com/mmistakes/minimal-mistakes/pull/2607)
 - Fix typo in installation documentation. [#2570](https://github.com/mmistakes/minimal-mistakes/pull/2570)
+- Fix broken Lunr search with Jekyll v4.1.0. [#2617](https://github.com/mmistakes/minimal-mistakes/pull/2617)
 
 ### Enhancements
 

--- a/assets/js/lunr/lunr-en.js
+++ b/assets/js/lunr/lunr-en.js
@@ -1,5 +1,5 @@
 ---
-layout: null
+layout: none
 ---
 
 var idx = lunr(function () {

--- a/assets/js/lunr/lunr-gr.js
+++ b/assets/js/lunr/lunr-gr.js
@@ -1,5 +1,5 @@
 ---
-layout: null
+layout: none
 ---
 
 step1list = new Array();

--- a/assets/js/lunr/lunr-store.js
+++ b/assets/js/lunr/lunr-store.js
@@ -1,5 +1,5 @@
 ---
-layout: null
+layout: none
 ---
 
 var store = [

--- a/docs/_docs/18-history.md
+++ b/docs/_docs/18-history.md
@@ -5,7 +5,7 @@ permalink: /docs/history/
 excerpt: "Change log of enhancements and bug fixes made to the theme."
 sidebar:
   nav: docs
-last_modified_at: 2020-07-23T12:13:57-04:00
+last_modified_at: 2020-07-24T00:00:00+00:00
 toc: false
 ---
 
@@ -16,6 +16,7 @@ toc: false
 - Add `relative_url` filter to author home link [#2575](https://github.com/mmistakes/minimal-mistakes/pull/2575)
 - Fix `analytics.provider` config comment to list all analytics providers. [#2607](https://github.com/mmistakes/minimal-mistakes/pull/2607)
 - Fix typo in installation documentation. [#2570](https://github.com/mmistakes/minimal-mistakes/pull/2570)
+- Fix broken Lunr search with Jekyll v4.1.0. [#2617](https://github.com/mmistakes/minimal-mistakes/pull/2617)
 
 ### Enhancements
 


### PR DESCRIPTION
This is a bug fix.

## Summary

Use `layout: none` instead of `layout: null` for Lunr JS files.

The `none` special layout is supported since Jekyll 3.7 (we're already requiring that as the minimum version) as a more robust replacement for either a missing key or `layout: null`. This should fix compatibility issues with Jekyll 4.1.0 (and potentially future issues should Jekyll decide to update something else).

See <https://github.com/jekyll/jekyll/issues/8217#issuecomment-640014789> (comment from Jekyll maintainer).

While it's in fact an upstream issue, a fix on our side should be harmless and good to have.

## Context

Fixes #2615