### PR TITLE
Wrap up post date and read time in <span> with class

### DIFF
--- a/_includes/post__meta.html
+++ b/_includes/post__meta.html
@@ -4,7 +4,7 @@
   <p class="page__meta">
 
     {% if page.show_date %}
-      <span class="page__meta-date">
+      <span class="post__meta-date">
         {% assign date = page.date %}
         <i class="far {% if include.type == 'grid' and page.read_time and page.show_date %}fa-fw {% endif %}fa-calendar-alt" aria-hidden="true"></i>
         <time datetime="{{ date | date_to_xmlschema }}">{{ date | date: "%B %-d, %Y" }}</time>
@@ -20,7 +20,7 @@
     {% endif %}
 
     {% if page.read_time %}
-      <span class="page__meta-read-time">
+      <span class="post__meta-read-time">
         {% assign words_per_minute = page.words_per_minute | default: site.words_per_minute | default: 200 %}
         {% assign words = page.content | strip_html | number_of_words %}
 

--- a/_includes/post__meta.html
+++ b/_includes/post__meta.html
@@ -4,9 +4,11 @@
   <p class="page__meta">
 
     {% if page.show_date %}
-      {% assign date = page.date %}
-      <i class="far {% if include.type == 'grid' and page.read_time and page.show_date %}fa-fw {% endif %}fa-calendar-alt" aria-hidden="true"></i>
-      <time datetime="{{ date | date_to_xmlschema }}">{{ date | date: "%B %-d, %Y" }}</time>
+      <span class="page__meta-date">
+        {% assign date = page.date %}
+        <i class="far {% if include.type == 'grid' and page.read_time and page.show_date %}fa-fw {% endif %}fa-calendar-alt" aria-hidden="true"></i>
+        <time datetime="{{ date | date_to_xmlschema }}">{{ date | date: "%B %-d, %Y" }}</time>
+      </span>
     {% endif %}
 
     {% if page.read_time and page.show_date %}
@@ -18,17 +20,19 @@
     {% endif %}
 
     {% if page.read_time %}
-      {% assign words_per_minute = page.words_per_minute | default: site.words_per_minute | default: 200 %}
-      {% assign words = page.content | strip_html | number_of_words %}
+      <span class="page__meta-read-time">
+        {% assign words_per_minute = page.words_per_minute | default: site.words_per_minute | default: 200 %}
+        {% assign words = page.content | strip_html | number_of_words %}
 
-      <i class="far {% if include.type == 'grid' and page.read_time and page.show_date %}fa-fw {% endif %}fa-clock" aria-hidden="true"></i>
-      {% if words < words_per_minute %}
-        {{ site.data.ui-text[site.locale].less_than | default: "less than" }} 1 {{ site.data.ui-text[site.locale].minute_read | default: "minute read" }}
-      {% elsif words == words_per_minute %}
-        1 {{ site.data.ui-text[site.locale].minute_read | default: "minute read" }}
-      {% else %}
-        {{ words | divided_by:words_per_minute }} {{ site.data.ui-text[site.locale].minute_read | default: "minute read" }}
-      {% endif %}
+        <i class="far {% if include.type == 'grid' and page.read_time and page.show_date %}fa-fw {% endif %}fa-clock" aria-hidden="true"></i>
+        {% if words < words_per_minute %}
+          {{ site.data.ui-text[site.locale].less_than | default: "less than" }} 1 {{ site.data.ui-text[site.locale].minute_read | default: "minute read" }}
+        {% elsif words == words_per_minute %}
+          1 {{ site.data.ui-text[site.locale].minute_read | default: "minute read" }}
+        {% else %}
+          {{ words | divided_by:words_per_minute }} {{ site.data.ui-text[site.locale].minute_read | default: "minute read" }}
+        {% endif %}
+      </span>
     {% endif %}
 
   </p>


### PR DESCRIPTION
This is an enhancement or feature.

## Summary

Post date and read time are now contained in an extra layer of `<span>` with BEM-named class, allowing for CSS-based customization (e.g. use different fonts for date and read time, and for post header and listing page).