### PR TITLE
Adds the ability for collections to not be indexed by Lunr by adding 'search: false' to _config.yml

### DIFF
--- a/assets/js/lunr/lunr-store.js
+++ b/assets/js/lunr/lunr-store.js
@@ -3,7 +3,8 @@ layout: none
 ---
 
 var store = [
-  {%- for c in site.collections -%}
+  {%- assign collections = site.collections | where_exp:'c','c.search != false' -%}
+  {%- for c in collections -%}
     {%- if forloop.last -%}
       {%- assign l = true -%}
     {%- endif -%}


### PR DESCRIPTION
This is an enhancement or feature.

## Summary

I've implemented the ability for collections to be searchable by configuring the 'search' setting under collections on _config.yml. I've maintained the same pattern used for defining searchable docs on lunr-store.js.

## Context

Although this is not related to any open GitHub issue, it was a very needed feature on a project of mine, and since it does not represent a major change on the code, and it seems like an useful feature for the average user, I've thought about sharing my simple code.