### PR TITLE
Removed duplicated CSS definitions

### DIFF
--- a/_sass/minimal-mistakes/_footer.scss
+++ b/_sass/minimal-mistakes/_footer.scss
@@ -8,7 +8,6 @@
   margin-left: 0;
   margin-right: 0;
   width: 100%;
-  clear: both;
   margin-top: 3em;
   color: $muted-text-color;
   -webkit-animation: $intro-transition;

--- a/_sass/minimal-mistakes/_sidebar.scss
+++ b/_sass/minimal-mistakes/_sidebar.scss
@@ -185,7 +185,6 @@
   vertical-align: middle;
   font-family: $sans-serif;
   z-index: 20;
-  position: relative;
   cursor: pointer;
 
   li:last-child {


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - Read the contributing document at https://github.com/mmistakes/minimal-mistakes#contributing
-->

<!--
  Choose one of the following by uncommenting it:
-->

This is a bug fix / improvement

## Summary

- `.author__urls-wrapper` has a duplicated `position: relative;` definition
- `. page__footer ` includes `clearfix` and defines ´clear: both;` on it's own which is duplciated then

## Context

<!--
  Is this related to any GitHub issue(s)?
-->