### PR TITLE
Fix dead link to "CI services" Jekyll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+### Bug Fixes
+
+- Fix dead link to CI services in documentation. [#2635](https://github.com/mmistakes/minimal-mistakes/issues/2635)
+
 ## [4.20.2](https://github.com/mmistakes/minimal-mistakes/releases/tag/4.20.2)
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Bug Fixes
 
-- Fix dead link to CI services in documentation. [#2635](https://github.com/mmistakes/minimal-mistakes/issues/2635)
+- Fix dead link to CI services in documentation. [#2635](https://github.com/mmistakes/minimal-mistakes/issues/2635) [#2692](https://github.com/mmistakes/minimal-mistakes/pull/2692)
 
 ## [4.20.2](https://github.com/mmistakes/minimal-mistakes/releases/tag/4.20.2)
 

--- a/docs/_docs/01-quick-start-guide.md
+++ b/docs/_docs/01-quick-start-guide.md
@@ -105,7 +105,7 @@ To do so fork the [Minimal Mistakes theme](https://github.com/mmistakes/minimal-
 
 [netlify-jekyll]: https://www.netlify.com/blog/2015/10/28/a-step-by-step-guide-jekyll-3.0-on-netlify/
 [gitlab-jekyll]: https://about.gitlab.com/2016/04/07/gitlab-pages-setup/
-[ci-jekyll]: https://jekyllrb.com/docs/continuous-integration/
+[ci-jekyll]: https://jekyllrb.com/docs/deployment/automated/#continuous-integration-service
 
 ### Remove the Unnecessary
 

--- a/docs/_docs/18-history.md
+++ b/docs/_docs/18-history.md
@@ -9,9 +9,15 @@ last_modified_at: 2020-09-07T10:03:41-04:00
 toc: false
 ---
 
+## Unreleased
+
+### Bug Fixes
+
+- Fix dead link to CI services in documentation. [#2635](https://github.com/mmistakes/minimal-mistakes/issues/2635)
+
 ## [4.20.2](https://github.com/mmistakes/minimal-mistakes/releases/tag/4.20.2)
 
-## Bug Fixes
+### Bug Fixes
 
 - Fix broken link in documentation. [#2677](https://github.com/mmistakes/minimal-mistakes/issues/2677)
 - Fix typo in documentation. [#2678](https://github.com/mmistakes/minimal-mistakes/issues/2678)

--- a/docs/_docs/18-history.md
+++ b/docs/_docs/18-history.md
@@ -13,7 +13,7 @@ toc: false
 
 ### Bug Fixes
 
-- Fix dead link to CI services in documentation. [#2635](https://github.com/mmistakes/minimal-mistakes/issues/2635)
+- Fix dead link to CI services in documentation. [#2635](https://github.com/mmistakes/minimal-mistakes/issues/2635) [#2692](https://github.com/mmistakes/minimal-mistakes/pull/2692)
 
 ## [4.20.2](https://github.com/mmistakes/minimal-mistakes/releases/tag/4.20.2)
 


### PR DESCRIPTION
This is a documentation change.

## Context

Fixes #2635