### PR TITLE
Fix Closing Tag of Figures Without Captions in Ordered and Unordered Lists

### DIFF
--- a/_includes/figure
+++ b/_includes/figure
@@ -1,9 +1,9 @@
 <figure class="{{ include.class }}">
   <img src="{{ include.image_path | relative_url }}"
        alt="{% if include.alt %}{{ include.alt }}{% endif %}">
-  {% if include.caption %}
+  {%- if include.caption -%}
     <figcaption>
       {{ include.caption | markdownify | remove: "<p>" | remove: "</p>" }}
     </figcaption>
-  {% endif %}
+  {%- endif -%}
 </figure>


### PR DESCRIPTION
This is a bug fix.

## Summary

This patch removes redundant `</figure>` tag rendered as text when the figure helper is used in a list, either ordered or unordered, and no caption is specified for that figure.

## Context

```md
---
layout: single
---

1. Lorem ipsum dolor sit amet

   {% include figure image_path="https://raw.githubusercontent.com/mmistakes/minimal-mistakes/master/screenshot.png" alt="Test image" %}

2. The quick brown fox jumps over the lazy dog
```

The above post is going to be rendered as in the image below. The figure is not captioned, which produces a redundant `</figure>` below it. Another noticeable issue is the next item that is supposed to be in the same list is put in a new list, resetting the number to 1.

![localhost_4000_2020_09_18_original-figure-helper html](https://user-images.githubusercontent.com/14175175/93628538-91d31b80-f99b-11ea-8108-4044947fb0aa.png)

After this patch is applied, the same post can be rendered correctly.

![localhost_4000_2020_09_18_patched-figure-helper html](https://user-images.githubusercontent.com/14175175/93628977-56851c80-f99c-11ea-858e-896c678e5a76.png)

The figure caption still works when the user specifies one.

```liquid
{% include figure image_path="https://raw.githubusercontent.com/mmistakes/minimal-mistakes/master/screenshot.png" alt="Test image" caption="hello, world"%}
```

![localhost_4000_2020_09_18_patched-figure-helper-test html](https://user-images.githubusercontent.com/14175175/93629028-6ac91980-f99c-11ea-89fc-9fc3a5de30c6.png)