### PR TITLE
Update nav_list to support FontAwesome icons on the left bar

### DIFF
--- a/_includes/nav_list
+++ b/_includes/nav_list
@@ -7,10 +7,13 @@
   <ul class="nav__items">
     {% for nav in navigation %}
       <li>
+        {% if nav.icon %}
+            {% capture icon %}<i class="{{ nav.icon }}" aria-hidden="true"></i> {% endcapture %}
+        {% endif %}
         {% if nav.url %}
-          <a href="{{ nav.url | relative_url }}"><span class="nav__sub-title">{{ nav.title }}</span></a>
+          <a href="{{ nav_url }}"><span class="nav__sub-title">{{ icon }}{{ nav.title }}</span></a>
         {% else %}
-          <span class="nav__sub-title">{{ nav.title }}</span>
+          <span class="nav__sub-title">{{ icon }}{{ nav.title }}</span>
         {% endif %}
 
         {% if nav.children != null %}


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - Read the contributing document at https://github.com/mmistakes/minimal-mistakes#contributing
-->

<!--
  Choose one of the following by uncommenting it:
-->

<!-- This is a bug fix. -->
This is an enhancement or feature.
<!-- This is a documentation change. -->

## Summary

Added the possibility to support icons in the navigation list on the left bar.

```
about-me:
  - title: "About me"
    icon: "fas fa-info-circle"
    url: /about/
  - title: "Resume"
    icon: "far fa-fw fa-file-pdf"
    url: "assets/files/resume.pdf"
```

## Context

When adding a navigation list on the left bar, it's now possible to add an icon using FontAwesome. [Here is a live example](https://renatogolia.com/about/)