### PR TITLE
Fix a small typo in documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fix greedy navigation by improving reliability of remaining space for visible links. [#2664](https://github.com/mmistakes/minimal-mistakes/issues/2664)
 - Collapse white-space in `figure` helper to fix issues when used in Markdown ordered and unordered lists. [#2697](https://github.com/mmistakes/minimal-mistakes/pull/2697)
 - Fix dead link to CI services in documentation. [#2635](https://github.com/mmistakes/minimal-mistakes/issues/2635) [#2692](https://github.com/mmistakes/minimal-mistakes/pull/2692)
+- Fix a small type in documentation. [#2718](https://github.com/mmistakes/minimal-mistakes/pull/2718)
 
 ## Enhancements
 

--- a/docs/_docs/14-helpers.md
+++ b/docs/_docs/14-helpers.md
@@ -249,7 +249,7 @@ To embed the following Bilibili video at url `https://www.bilibili.com/video/BV1
 {% raw %}{% include video id="BV1E7411e7hC" provider="bilibili" %}{% endraw %}
 ```
 
-If you want to enable danmaku (弹幕) for the embeded video, which is disabled by default, you can supply an additional parameter `danmaku="1"` as shown below: 
+If you want to enable danmaku (弹幕) for the embedded video, which is disabled by default, you can supply an additional parameter `danmaku="1"` as shown below: 
 
 ```liquid
 {% raw %}{% include video id="BV1E7411e7hC" provider="bilibili" danmaku="1" %}{% endraw %}

--- a/docs/_docs/18-history.md
+++ b/docs/_docs/18-history.md
@@ -16,6 +16,7 @@ toc: false
 - Fix greedy navigation by improving reliability of remaining space for visible links. [#2664](https://github.com/mmistakes/minimal-mistakes/issues/2664)
 - Collapse white-space in `figure` helper to fix issues when used in Markdown ordered and unordered lists. [#2697](https://github.com/mmistakes/minimal-mistakes/pull/2697)
 - Fix dead link to CI services in documentation. [#2635](https://github.com/mmistakes/minimal-mistakes/issues/2635) [#2692](https://github.com/mmistakes/minimal-mistakes/pull/2692)
+- Fix a small type in documentation. [#2718](https://github.com/mmistakes/minimal-mistakes/pull/2718)
 
 ## Enhancements
 


### PR DESCRIPTION
This is a bug fix.

## Summary

`embeded` → `embedded`

The original spelling missed the double D.