### PR TITLE
Allow custom sorting for collections

### DIFF
--- a/_includes/documents-collection.html
+++ b/_includes/documents-collection.html
@@ -1,16 +1,14 @@
 {% assign entries = site[include.collection] %}
 
-{% if include.sort_by == 'title' %}
+{% if include.sort_by %}
   {% if include.sort_order == 'reverse' %}
-    {% assign entries = entries | sort: 'title' | reverse %}
+    {% assign entries = entries | sort: include.sort_by | reverse %}
   {% else %}
-    {% assign entries = entries | sort: 'title' %}
+    {% assign entries = entries | sort: include.sort_by %}
   {% endif %}
-{% elsif include.sort_by == 'date' %}
+{% else %}
   {% if include.sort_order == 'reverse' %}
-    {% assign entries = entries | sort: 'date' | reverse %}
-  {% else %}
-    {% assign entries = entries | sort: 'date' %}
+    {% assign entries = entries | reverse %}
   {% endif %}
 {% endif %}
 

--- a/_includes/documents-collection.html
+++ b/_includes/documents-collection.html
@@ -1,15 +1,11 @@
 {% assign entries = site[include.collection] %}
 
 {% if include.sort_by %}
-  {% if include.sort_order == 'reverse' %}
-    {% assign entries = entries | sort: include.sort_by | reverse %}
-  {% else %}
-    {% assign entries = entries | sort: include.sort_by %}
-  {% endif %}
-{% else %}
-  {% if include.sort_order == 'reverse' %}
-    {% assign entries = entries | reverse %}
-  {% endif %}
+  {% assign entries = entries | sort: include.sort_by %}
+{% endif %}
+
+{% if include.sort_order == 'reverse' %}
+  {% assign entries = entries | reverse %}
 {% endif %}
 
 {%- for post in entries -%}

--- a/docs/_docs/10-layouts.md
+++ b/docs/_docs/10-layouts.md
@@ -249,7 +249,7 @@ This layout displays all documents grouped by a specific collection. It accommod
 collection: # collection name
 entries_layout: # list (default), grid
 show_excerpts: # true (default), false
-sort_by: # date (default) title
+sort_by: # date (default), title or any metadata key added to the collection's documents
 sort_order: # forward (default), reverse
 ```
 
@@ -263,6 +263,11 @@ collection: recipes
 ```
 
 If you want to sort the collection by title add `sort_by: title`. If you want reverse sorting, add `sort_order: reverse`.
+You can also use any metadata key that is present in the documents. For example, you can add `number: <any number>` to your documents and use `number` as the sort key:
+
+```yaml
+sort_by: number
+```
 
 ### `layout: category`
 


### PR DESCRIPTION
This is an enhancement or feature.

## Summary

This PR allows sorting of collections by custom keys. This is done by using directly the `include.sort_by` value in sort tag instead of testing it's value.