### PR TITLE
Fix show_excerpts in collection layout's front matter

### DIFF
--- a/_includes/archive-single.html
+++ b/_includes/archive-single.html
@@ -10,6 +10,12 @@
   {% assign title = post.title %}
 {% endif %}
 
+{% if show_excerpts == false %}
+  {% assign show_excerpt = false %}
+{% else %}
+  {% assign show_excerpt = true %}
+{% endif %}
+
 <div class="{{ include.type | default: 'list' }}__item">
   <article class="archive__item" itemscope itemtype="https://schema.org/CreativeWork">
     {% if include.type == "grid" and teaser %}
@@ -25,6 +31,6 @@
       {% endif %}
     </h2>
     {% include page__meta.html type=include.type %}
-    {% if post.excerpt %}<p class="archive__item-excerpt" itemprop="description">{{ post.excerpt | markdownify | strip_html | truncate: 160 }}</p>{% endif %}
+    {% if show_excerpt and post.excerpt %}<p class="archive__item-excerpt" itemprop="description">{{ post.excerpt | markdownify | strip_html | truncate: 160 }}</p>{% endif %}
   </article>
 </div>

--- a/_includes/archive-single.html
+++ b/_includes/archive-single.html
@@ -10,12 +10,6 @@
   {% assign title = post.title %}
 {% endif %}
 
-{% if show_excerpts == false %}
-  {% assign show_excerpt = false %}
-{% else %}
-  {% assign show_excerpt = true %}
-{% endif %}
-
 <div class="{{ include.type | default: 'list' }}__item">
   <article class="archive__item" itemscope itemtype="https://schema.org/CreativeWork">
     {% if include.type == "grid" and teaser %}
@@ -31,6 +25,6 @@
       {% endif %}
     </h2>
     {% include page__meta.html type=include.type %}
-    {% if show_excerpt and post.excerpt %}<p class="archive__item-excerpt" itemprop="description">{{ post.excerpt | markdownify | strip_html | truncate: 160 }}</p>{% endif %}
+    {% if show_excerpts != false and post.excerpt %}<p class="archive__item-excerpt" itemprop="description">{{ post.excerpt | markdownify | strip_html | truncate: 160 }}</p>{% endif %}
   </article>
 </div>

--- a/_layouts/collection.html
+++ b/_layouts/collection.html
@@ -5,11 +5,7 @@ layout: archive
 {{ content }}
 
 {% assign entries_layout = page.entries_layout | default: 'list' %}
-{% if page.show_excerpts == false %}
-  {% assign show_excerpts = false %}
-{% else %}
-  {% assign show_excerpts = true %}
-{% endif %}
+{% assign show_excerpts = page.show_excerpts != false %}
 <div class="entries-{{ entries_layout }}">
   {% include documents-collection.html collection=page.collection sort_by=page.sort_by sort_order=page.sort_order type=entries_layout %}
 </div>

--- a/_layouts/collection.html
+++ b/_layouts/collection.html
@@ -5,6 +5,11 @@ layout: archive
 {{ content }}
 
 {% assign entries_layout = page.entries_layout | default: 'list' %}
+{% if page.show_excerpts == false %}
+  {% assign show_excerpts = false %}
+{% else %}
+  {% assign show_excerpts = true %}
+{% endif %}
 <div class="entries-{{ entries_layout }}">
   {% include documents-collection.html collection=page.collection sort_by=page.sort_by sort_order=page.sort_order type=entries_layout %}
 </div>


### PR DESCRIPTION
This is a bug fix.
## Summary
The `show_excerpts` front matter in [collection layout](https://mmistakes.github.io/minimal-mistakes/docs/layouts/#layout-collection) doesn't work as documented for now. Fixed it.
