### PR TITLE
Update remote theme instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ To install:
    source "https://rubygems.org"
 
    gem "github-pages", group: :jekyll_plugins
+   gem "jekyll-include-cache", group: :jekyll_plugins
    ```
 
 2. Add `jekyll-include-cache` to the `plugins` array of your `_config.yml`.

--- a/docs/_docs/01-quick-start-guide.md
+++ b/docs/_docs/01-quick-start-guide.md
@@ -64,6 +64,7 @@ To install as a remote theme:
    source "https://rubygems.org"
 
    gem "github-pages", group: :jekyll_plugins
+   gem "jekyll-include-cache", group: :jekyll_plugins
    ```
 
 2. Add `jekyll-include-cache` to the `plugins` array of your `_config.yml`.


### PR DESCRIPTION

<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - Read the contributing document at https://github.com/mmistakes/minimal-mistakes#contributing
-->

<!--
  Choose one of the following by uncommenting it:
-->

<!-- This is a bug fix. -->
<!-- This is an enhancement or feature. -->
This is a documentation change.

## Summary

Update remote theme installation instructions to indicate that `jekyll-include-cache` should be added to the Gemfile.

## Context

I followed the [remote theme installation](https://github.com/mmistakes/minimal-mistakes#remote-theme-method) instructions and got the following error when running `bundle exec jekyll serve`:

```
Dependency Error: Yikes! It looks like you don't have jekyll-include-cache or one of its dependencies installed. In order to use Jekyll as currently configured, you'll need to install this gem. The full error message from Ruby is: 'cannot load such file -- jekyll-include-cache' If you run into trouble, you can find helpful resources at https://jekyllrb.com/help/! 
```

Adding the `jekyll-include-cache` gem to my Gemfile resolved the error, so it should probably be part of the instructions.