### PR TITLE
WIP Use page.lang or site.lang if it exist

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -8,7 +8,16 @@
   Free for personal and commercial use under the MIT license
   https://github.com/mmistakes/minimal-mistakes/blob/master/LICENSE
 -->
-<html lang="{{ site.locale | slice: 0,2 | default: "en" }}" class="no-js">
+{% capture locale %}
+  {% if page.lang %}
+    {{ page.lang }}
+  {% elsif site.lang %}
+    {{ site.lang }}
+  {% else %}
+    {{ site.locale | slice: 0,2 }}
+{% endcapture %}
+
+<html lang="{{ locale | default: "en" }}" class="no-js">
   <head>
     {% include head.html %}
     {% include head/custom.html %}


### PR DESCRIPTION
This is an enhancement or feature.

WIP. DO NOT MERGE

TODO:
- [ ] Update doc about this change

## Summary 
Use `page.lang` or `site.lang` if it exist on page front matter or site config.
`jekyll-feed` use site & post lang to generate `xml:lang` property on `feed.xml`.

## Reference
- https://github.com/jekyll/jekyll-feed/blob/master/lib/jekyll-feed/feed.xml#L5
- https://github.com/jekyll/jekyll-feed/blob/master/lib/jekyll-feed/feed.xml#L56

## Use case
User can use specific `lang` frontmatter if they want specific post or page to use different language.
Preserve fallback by still use `site.locale` if `page.lang` or `site.lang` dont exist.
Reason for using `lang` is because they are used by `jekyll-feed`.