### PR TITLE
Use sort_natural instead of custom-logic

### DIFF
--- a/_includes/category-list.html
+++ b/_includes/category-list.html
@@ -6,19 +6,12 @@
 {% endcase %}
 
 {% if site.category_archive.path %}
-  {% comment %}
-    <!-- Sort alphabetically regardless of case e.g. a B c d E -->
-    <!-- modified from http://www.codeofclimber.ru/2015/sorting-site-tags-in-jekyll/ -->
-  {% endcomment %}
-  {% capture page_categories %}{% for category in page.categories %}{{ category | downcase }}|{{ category }}{% unless forloop.last %},{% endunless %}{% endfor %}{% endcapture %}
-  {% assign category_hashes = page_categories | split: ',' | sort %}
+  {% assign categories_sorted = page.categories | sort_natural %}
 
   <p class="page__taxonomy">
     <strong><i class="fas fa-fw fa-folder-open" aria-hidden="true"></i> {{ site.data.ui-text[site.locale].categories_label | default: "Categories:" }} </strong>
     <span itemprop="keywords">
-    {% for hash in category_hashes %}
-      {% assign keyValue = hash | split: '|' %}
-      {% capture category_word %}{{ keyValue[1] | strip_newlines }}{% endcapture %}
+    {% for category_word in categories_sorted %}
       <a href="{{ category_word | slugify | prepend: path_type | prepend: site.category_archive.path | relative_url }}" class="page__taxonomy-item" rel="tag">{{ category_word }}</a>{% unless forloop.last %}<span class="sep">, </span>{% endunless %}
     {% endfor %}
     </span>

--- a/_includes/tag-list.html
+++ b/_includes/tag-list.html
@@ -6,19 +6,12 @@
 {% endcase %}
 
 {% if site.tag_archive.path %}
-  {% comment %}
-    <!-- Sort alphabetically regardless of case e.g. a B c d E -->
-    <!-- modified from http://www.codeofclimber.ru/2015/sorting-site-tags-in-jekyll/ -->
-  {% endcomment %}
-  {% capture page_tags %}{% for tag in page.tags %}{{ tag | downcase }}|{{ tag }}{% unless forloop.last %},{% endunless %}{% endfor %}{% endcapture %}
-  {% assign tag_hashes = page_tags | split: ',' | sort %}
+  {% assign tags_sorted = page.tags | sort_natural %}
 
   <p class="page__taxonomy">
     <strong><i class="fas fa-fw fa-tags" aria-hidden="true"></i> {{ site.data.ui-text[site.locale].tags_label | default: "Tags:" }} </strong>
     <span itemprop="keywords">
-    {% for hash in tag_hashes %}
-      {% assign keyValue = hash | split: '|' %}
-      {% capture tag_word %}{{ keyValue[1] | strip_newlines }}{% endcapture %}
+    {% for tag_word in tags_sorted %}
       <a href="{{ tag_word | slugify | prepend: path_type | prepend: site.tag_archive.path | relative_url }}" class="page__taxonomy-item" rel="tag">{{ tag_word }}</a>{% unless forloop.last %}<span class="sep">, </span>{% endunless %}
     {% endfor %}
     </span>


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - Read the contributing document at https://github.com/mmistakes/minimal-mistakes#contributing
-->

<!--
  Choose one of the following by uncommenting it:
-->

<!-- This is a bug fix. -->
This is an enhancement or feature. 
<!-- This is a documentation change. -->

## Summary

<!--
  Provide a description of what your pull request changes.
-->
- The sorting logic for tags and categories is done by custom-logic. I thought it's cleaner code to use `sort_natural` which exists out of the box for that use-case. See documentation at https://shopify.github.io/liquid/filters/sort_natural/
- Afaik this method was introduced in Jekyll 3.5, means it would be a requirement to have at least that version. However it's been released some years ago and is supported by GitHub Pages, so don't think it's breaking something

## Context

<!--
  Is this related to any GitHub issue(s)?
-->