### PR TITLE
add extension point to add scripts at the end of html page

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -37,6 +37,7 @@
     </div>
 
     {% include scripts.html %}
+    {% include custom/myscripts.html %}
 
   </body>
 </html>


### PR DESCRIPTION
This is an enhancement or feature.

## Summary

I have created an overridable file `myscripts.html` and include it at the end of `default.html` to be able to control more accurately some JS execution. I also made the customization point more visible by creating a folder `custom` in the `_includes` folder.

## Context

It is sometimes useful to control the execution of some javascript being able to add them at
the end helped me to have the right rendering.