### PR TITLE
footer: Add ability to hide the RSS Feed item

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -12,7 +12,9 @@
       {% endfor %}
     {% endif %}
 
-    <li><a href="{% if site.atom_feed.path %}{{ site.atom_feed.path }}{% else %}{{ '/feed.xml' | relative_url }}{% endif %}"><i class="fas fa-fw fa-rss-square" aria-hidden="true"></i> {{ site.data.ui-text[site.locale].feed_label | default: "Feed" }}</a></li>
+    {% if site.atom_feed.show or site.atom_feed.path %}
+      <li><a href="{% if site.atom_feed.path %}{{ site.atom_feed.path }}{% else %}{{ '/feed.xml' | relative_url }}{% endif %}"><i class="fas fa-fw fa-rss-square" aria-hidden="true"></i> {{ site.data.ui-text[site.locale].feed_label | default: "Feed" }}</a></li>
+    {% endif %}
   </ul>
 </div>
 


### PR DESCRIPTION
This is an enhancement or feature.

## Summary

In _config.yml atom already exists and is a dictionary, so I could simply add a "show" key, and for backwards compatibility, it will still work as long as `atom.path` isn't empty.

## Context

I want to create a documentation-only page using mm, which won't use jekyll-feed at all, so having a 404'ing RSS feed enforced isn't ideal.