### PR TITLE
Add toggle option for RSS feed visibility

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -51,6 +51,7 @@ reCaptcha:
   secret                 :
 atom_feed:
   path                   : # blank (default) uses feed.xml
+  hide                   : # true, false (default)
 search                   : # true, false (default)
 search_full_content      : # true, false (default)
 search_provider          : # lunr (default), algolia, google

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -12,7 +12,9 @@
       {% endfor %}
     {% endif %}
 
+    {% if !site.atom_feed.hide %}
     <li><a href="{% if site.atom_feed.path %}{{ site.atom_feed.path }}{% else %}{{ '/feed.xml' | relative_url }}{% endif %}"><i class="fas fa-fw fa-rss-square" aria-hidden="true"></i> {{ site.data.ui-text[site.locale].feed_label | default: "Feed" }}</a></li>
+    {% endif %}
   </ul>
 </div>
 

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -12,9 +12,9 @@
       {% endfor %}
     {% endif %}
 
-    {% if !site.atom_feed.hide %}
-    <li><a href="{% if site.atom_feed.path %}{{ site.atom_feed.path }}{% else %}{{ '/feed.xml' | relative_url }}{% endif %}"><i class="fas fa-fw fa-rss-square" aria-hidden="true"></i> {{ site.data.ui-text[site.locale].feed_label | default: "Feed" }}</a></li>
-    {% endif %}
+    {% unless site.atom_feed.hide %}
+      <li><a href="{% if site.atom_feed.path %}{{ site.atom_feed.path }}{% else %}{{ '/feed.xml' | relative_url }}{% endif %}"><i class="fas fa-fw fa-rss-square" aria-hidden="true"></i> {{ site.data.ui-text[site.locale].feed_label | default: "Feed" }}</a></li>
+    {% endunless %}
   </ul>
 </div>
 

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -2,10 +2,10 @@
 
 {% include seo.html %}
 
-{% if !site.atom_feed.hide %}
+{% unless site.atom_feed.hide %}
 <link href="{% if site.atom_feed.path %}{{ site.atom_feed.path }}{% else %}{{ '/feed.xml' | relative_url }}{% endif %}"
   type="application/atom+xml" rel="alternate" title="{{ site.title }} Feed">
-{% endif %}
+{% endunless %}
 
 <!-- https://t.co/dKP3o1e -->
 <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -34,7 +34,7 @@
 <![endif]-->
 
 {% if site.head_scripts %}
-{% for script in site.head_scripts %}
-<script src="{{ script | relative_url }}"></script>
-{% endfor %}
+  {% for script in site.head_scripts %}
+    <script src="{{ script | relative_url }}"></script>
+  {% endfor %}
 {% endif %}

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -2,7 +2,10 @@
 
 {% include seo.html %}
 
-<link href="{% if site.atom_feed.path %}{{ site.atom_feed.path }}{% else %}{{ '/feed.xml' | relative_url }}{% endif %}" type="application/atom+xml" rel="alternate" title="{{ site.title }} Feed">
+{% if !site.atom_feed.hide %}
+<link href="{% if site.atom_feed.path %}{{ site.atom_feed.path }}{% else %}{{ '/feed.xml' | relative_url }}{% endif %}"
+  type="application/atom+xml" rel="alternate" title="{{ site.title }} Feed">
+{% endif %}
 
 <!-- https://t.co/dKP3o1e -->
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -31,7 +34,7 @@
 <![endif]-->
 
 {% if site.head_scripts %}
-  {% for script in site.head_scripts %}
-    <script src="{{ script | relative_url }}"></script>
-  {% endfor %}
+{% for script in site.head_scripts %}
+<script src="{{ script | relative_url }}"></script>
+{% endfor %}
 {% endif %}

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -3,8 +3,7 @@
 {% include seo.html %}
 
 {% unless site.atom_feed.hide %}
-<link href="{% if site.atom_feed.path %}{{ site.atom_feed.path }}{% else %}{{ '/feed.xml' | relative_url }}{% endif %}"
-  type="application/atom+xml" rel="alternate" title="{{ site.title }} Feed">
+  <link href="{% if site.atom_feed.path %}{{ site.atom_feed.path }}{% else %}{{ '/feed.xml' | relative_url }}{% endif %}" type="application/atom+xml" rel="alternate" title="{{ site.title }} Feed">
 {% endunless %}
 
 <!-- https://t.co/dKP3o1e -->

--- a/docs/_docs/05-configuration.md
+++ b/docs/_docs/05-configuration.md
@@ -559,6 +559,15 @@ atom_feed:
 **Note:** By default the site feed is linked in two locations: inside the [`<head>` element](https://github.com/mmistakes/minimal-mistakes/blob/master/_includes/head.html) and at the bottom of every page in the [site footer](https://github.com/mmistakes/minimal-mistakes/blob/master/_includes/footer.html).
 {: .notice--info}
 
+### Disable Feed Icons
+
+By default the theme links to `feed.xml` generated in the root of your site by the **jekyll-feed** plugin. To remove the RSS icon in the header and footer, update `atom_feed` in `_config.yml` like so:
+
+```yaml
+atom_feed:
+  hide: true
+```
+
 ### Site search
 
 To enable site-wide search add `search: true` to your `_config.yml`.


### PR DESCRIPTION
This is an enhancement or feature.

## Summary

Adds a `hide` property to the `atom_feed` in `_config.yml`. When `hide` is set to `true` (`false` by default), prevents the header and footer from rendering the RSS feed icons.

## Context

Resolves #2786.