### PR TITLE
Add .webp to supported lightbox images

### DIFF
--- a/assets/js/_main.js
+++ b/assets/js/_main.js
@@ -83,7 +83,7 @@ $(document).ready(function() {
 
   // add lightbox class to all image links
   $(
-    "a[href$='.jpg'],a[href$='.jpeg'],a[href$='.JPG'],a[href$='.png'],a[href$='.gif']"
+    "a[href$='.jpg'],a[href$='.jpeg'],a[href$='.JPG'],a[href$='.png'],a[href$='.gif'],a[href$='.webp']"
   ).addClass("image-popup");
 
   // Magnific-Popup options


### PR DESCRIPTION
This is an enhancement or feature.

## Summary

Adds .webp to list of supported image extensions for the image popup lightbox.

## Context

I prefer to use .webp image assets, so this would be nice.