### PR TITLE
Remove google's fixurl.js from example

### DIFF
--- a/test/_pages/404.md
+++ b/test/_pages/404.md
@@ -5,12 +5,4 @@ sitemap: false
 permalink: /404.html
 ---
 
-Sorry, but the page you were trying to view does not exist --- perhaps you can try searching for it below.
-
-<script type="text/javascript">
-  var GOOG_FIXURL_LANG = 'en';
-  var GOOG_FIXURL_SITE = '{{ site.url }}'
-</script>
-<script type="text/javascript"
-  src="//linkhelp.clients.google.com/tbproxy/lh/wm/fixurl.js">
-</script>
+Sorry, but the page you were trying to view does not exist.


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - Read the contributing document at https://github.com/mmistakes/minimal-mistakes#contributing
-->

<!--
  Choose one of the following by uncommenting it:
-->

This is a bug fix. 
<!-- This is an enhancement or feature. -->
<!-- This is a documentation change. -->

## Summary

Unfortunately, fixurl.js no longer exists and I couldn't find a suitable replacement quickly. Submitting this to remove the bad link.

Per: 

* #2597 
* https://webmasters.googleblog.com/2008/08/make-your-404-pages-more-useful.html
* https://developers.google.com/search/blog/2008/08/make-your-404-pages-more-useful