### PR TITLE
Remove all references to official public Staticman API instance.

### DIFF
--- a/_includes/comments.html
+++ b/_includes/comments.html
@@ -35,7 +35,7 @@
           <div class="page__comments-form">
             <h4 class="page__comments-title">{{ site.data.ui-text[site.locale].comments_label | default: "Leave a Comment" }}</h4>
             <p class="small">{{ site.data.ui-text[site.locale].comment_form_info | default: "Your email address will not be published. Required fields are marked" }} <span class="required">*</span></p>
-            <form id="new_comment" class="page__comments-form js-form form" method="post" action="{{ site.comments.staticman.endpoint | default: 'https://api.staticman.net/v2/entry/' }}{{ site.repository }}/{{ site.comments.staticman.branch }}/comments">
+            <form id="new_comment" class="page__comments-form js-form form" method="post" action="{{ site.comments.staticman.endpoint }}{{ site.repository }}/{{ site.comments.staticman.branch }}/comments">
               <div class="form__spinner">
                 <i class="fas fa-spinner fa-spin fa-3x fa-fw"></i>
                 <span class="sr-only">{{ site.data.ui-text[site.locale].loading_label | default: "Loading..." }}</span>

--- a/docs/_docs/05-configuration.md
+++ b/docs/_docs/05-configuration.md
@@ -527,7 +527,7 @@ By default comment moderation is enabled in `staticman.yml`. As new comments are
 
 To skip this moderation step simply set `moderation: false`.
 
-**ProTip:** Create a GitHub webhook that sends a `POST` request to the following payload URL `https://api.staticman.net/v2/webhook` and triggers a "Pull request" event to delete Staticman branches on merge.
+**ProTip:** Create a GitHub webhook that sends a `POST` request to the following payload URL `https://{your Staticman API URL}/v2/webhook` and triggers a "Pull request" event to delete Staticman branches on merge.
 {: .notice--info}
 
 ![pull-request webhook]({{ "/assets/images/mm-staticman-pr-webhook.jpg" | relative_url }})

--- a/docs/_docs/05-configuration.md
+++ b/docs/_docs/05-configuration.md
@@ -334,7 +334,7 @@ For example,
 | **disqus**       | Disqus                    |
 | **discourse**    | Discourse                 |
 | **facebook**     | Facebook Comments         |
-| **staticman_v2** | Staticman v2              |
+| **staticman_v2** | Staticman v2 / v3         |
 | **staticman**    | Staticman v1 (deprecated) |
 | **utterances**   | utterances                |
 | **custom**       | Other                     |
@@ -425,13 +425,16 @@ Transform user comments into `_data` files that live inside of your GitHub repos
 **Note:** Looking to migrate comments from a WordPress based site? Give [this tool](https://github.com/arthurlacoste/wordpress-comments-jekyll-staticman) a try.
 {: .notice--info}
 
-**Note:** Please note that as of September 2018, Staticman is reaching GitHub API limits due to its popularity, and it is recommended by its maintainer that users deploy their own instances for production (use `site.staticman.endpoint`).
+**Note:** Please note that as of September 2018, Staticman is reaching GitHub API limits due to its popularity, and it is recommended by its maintainer that users deploy their own instances for production (use `site.staticman.endpoint`).  Consult the Staticman "[Get Started](https://staticman.net/docs/index.html)" guide for more info.
 {: .notice--warning}
 
-##### Add Staticman as a collaborator
+##### Add Staticman as a collaborator on GitHub (legacy)
 
-1. Allow Staticman push access to your GitHub repository by clicking on **Settings**, then the **Collaborators** tab and adding `staticmanapp` as a collaborator.
-2. To accept the pending invitation visit: `https://api.staticman.net/v2/connect/{your GitHub username}/{your repository name}`. Consult the Staticman "[Get Started](https://staticman.net/docs/index.html)" guide for more info.
+1. Allow Staticman push access to your GitHub repository by clicking on **Settings**, then the **Collaborators** tab and adding your GitHub bot as a collaborator.
+2. To accept the pending invitation visit: `https://{your Staticman v2/3 API}/v[2|3]/connect/{your GitHub username}/{your repository name}`.
+
+**Note:** The new GitHub App authentication method is recommended for GitHub repositories to avoid the API rate limit.
+{: .notice--info}
 
 ##### Configure Staticman
 

--- a/staticman.yml
+++ b/staticman.yml
@@ -3,7 +3,7 @@
 # For example, you can have one property to handle comment submission and
 # another one to handle posts.
 # To encrypt strings use the following endpoint:
-# https://api.staticman.net/v2/encrypt/{TEXT TO BE ENCRYPTED}
+# https://{your Staticman API URL}/v[2|3]/encrypt/{TEXT TO BE ENCRYPTED}
 
 comments:
   # (*) REQUIRED


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - Read the contributing document at https://github.com/mmistakes/minimal-mistakes#contributing
-->

<!--
  Choose one of the following by uncommenting it:
-->

This is a bug fix.
<!-- This is an enhancement or feature. -->
This is a documentation change.

## Summary

<!--
  Provide a description of what your pull request changes.
-->

1. removed any references to the public official API instance "api dot staticman dot net" as Staticman's maintains has recommended users to stay away from it.
    1. replaced `api.staticman.net` in the docs with `{your Staticman API URL}` in the docs
    2. (breaking change) removed the fallback to the public official API instance in the Jekyll-HTML template to encourage existing users to self-host their own instance
2. change `v2` to `v[2|3]` in the docs to encourage users to use the v3 API scheme.  For v3 users, the `/v2/encrypt` in `staticman.yml` might be confusing.
3. labelled the existing GitHub bot authorization mechanism as "legacy" in favor of the new GitHub App way, which avoids GitHub's rate API limit.
4. moved the link to Staticman's quick start guide to the first notice: the linked offiical Staticman setup guide has recently been updated.  It covers both v2 and v3.  It's easier for us (theme maintainer/contributor) to refer (potential/existing) users to the official site in order to avoid overloading our docs page with too technical info about Staticman.

## Context

<!--
  Is this related to any GitHub issue(s)?
-->

- resolve #2818 
- docs update subsequent to eduardoboucas/staticman.net#13
- Staticman's maintainer's recommendation: https://github.com/eduardoboucas/staticman/issues/317#issuecomment-565250060