### PR TITLE
feature_row can accept an array with feature rows

### DIFF
--- a/_includes/feature_row
+++ b/_includes/feature_row
@@ -1,5 +1,7 @@
 {% if include.id %}
   {% assign feature_row = page[include.id] %}
+{% elsif include.rows %}
+  {% assign feature_row = include.rows %}
 {% else %}
   {% assign feature_row = page.feature_row %}
 {% endif %}

--- a/docs/_docs/14-helpers.md
+++ b/docs/_docs/14-helpers.md
@@ -157,10 +157,11 @@ feature_row:
 
 And then drop-in the feature row include in the body where you'd like it to appear.
 
-| Include Parameter | Required | Description                                                                                                                                                | Default       |
-| ----------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
-| **id**            | Optional | To add multiple rows to a document uniquely name them in the YAML Front Matter and reference in `{% raw %}{% include feature_row id="row2" %}{% endraw %}` | `feature_row` |
-| **type**          | Optional | Alignment of the featured blocks in the row. Options include: `left`, `center`, or `right` aligned.                                                        |               |
+| Include Parameter | Required | Description                                                                                                                                                           | Default       |
+| ----------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| **id**            | Optional | To add multiple rows to a document uniquely name them in the YAML Front Matter and reference in `{% raw %}{% include feature_row id="row2" %}{% endraw %}`            | `feature_row` |
+| **rows**          | Optional | To add an array with rows specified in YAML with the same structure and reference it like this `{% raw %}{% include feature_row rows=page.feature_row %}{% endraw %}` |               |
+| **type**          | Optional | Alignment of the featured blocks in the row. Options include: `left`, `center`, or `right` aligned.                                                                   |               |
 
 ```liquid
 {% raw %}{% include feature_row %}{% endraw %}


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - Read the contributing document at https://github.com/mmistakes/minimal-mistakes#contributing
-->

<!--
  Choose one of the following by uncommenting it:
-->

<!-- This is a bug fix. -->
This is an enhancement or feature.
<!-- This is a documentation change. -->

## Summary

<!--
  Provide a description of what your pull request changes.
-->

This pull request makes the `feature_row` more versatile, so you can add rows without having to specify the rows in the frontmatter.

## Context

There might be many situations where you want to store your feature rows other places than in the frontmatter and be able to query your rows. This makes it possible to still use the standard theme.

<!--
  Is this related to any GitHub issue(s)?
-->