### PR TITLE
Make it possible to add an array of images

### DIFF
--- a/_includes/gallery
+++ b/_includes/gallery
@@ -1,5 +1,7 @@
 {% if include.id %}
   {% assign gallery = page[include.id] %}
+{% elsif include.images %}
+  {% assign gallery = include.images %}
 {% else %}
   {% assign gallery = page.gallery %}
 {% endif %}

--- a/docs/_docs/14-helpers.md
+++ b/docs/_docs/14-helpers.md
@@ -102,12 +102,13 @@ gallery:
 
 And then drop-in the gallery include in the body where you'd like it to appear.
 
-| Include Parameter | Required | Description                                                                                                                                                       | Default                                                                      |
-| ----------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
-| **id**            | Optional | To add multiple galleries to a document uniquely name them in the YAML Front Matter and reference in `{% raw %}{% include gallery id="gallery_id" %}{% endraw %}` | `gallery`                                                                    |
-| **layout**        | Optional | Layout type. 2 column: `half`, 3 column: `third`, single column: `''` (blank)                                                                                     | Determined by gallery size. Two items: `half`, three or more items: `third`. |
-| **class**         | Optional | Use to add a `class` attribute to the surrounding `<figure>` element for additional styling needs.                                                                |                                                                              |
-| **caption**       | Optional | Gallery caption description. Markdown is allowed.                                                                                                                 |                                                                              |
+| Include Parameter | Required | Description                                                                                                                                                                   | Default                                                                      |
+| ----------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| **id**            | Optional | To add multiple galleries to a document uniquely name them in the YAML Front Matter and reference in `{% raw %}{% include gallery id="gallery_id" %}{% endraw %}`             | `gallery`                                                                  |
+| **images**        | Optional | You can also add multiple galleries by supplying an array with images specified in YAML and reference in `{% raw %}{% include gallery images=page.gallery_id %}{% endraw %}`  |                                                                     |
+| **layout**        | Optional | Layout type. 2 column: `half`, 3 column: `third`, single column: `''` (blank)                                                                                                 | Determined by gallery size. Two items: `half`, three or more items: `third`. |
+| **class**         | Optional | Use to add a `class` attribute to the surrounding `<figure>` element for additional styling needs.                                                                            |                                                                              |
+| **caption**       | Optional | Gallery caption description. Markdown is allowed.                                                                                                                             |                                                                              |
 
 ```liquid
 {% raw %}{% include gallery caption="This is a sample gallery with **Markdown support**." %}{% endraw %}


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - Read the contributing document at https://github.com/mmistakes/minimal-mistakes#contributing
-->

<!--
  Choose one of the following by uncommenting it:
-->

<!-- This is a bug fix. -->
This is an enhancement or feature.
<!-- This is a documentation change. -->

## Summary

<!--
  Provide a description of what your pull request changes.
-->

This pull request makes the `gallery` more versatile, so you can add rows without having to specify the rows in the frontmatter.

## Context

There might be many situations where you want to store your gallery images other places than in the frontmatter and be able to query your images. This makes it possible to still use the standard theme.

<!--
  Is this related to any GitHub issue(s)?
-->