### PR TITLE
Made it possible for a rel-attribute for feature_row and gallery

### DIFF
--- a/_includes/feature_row
+++ b/_includes/feature_row
@@ -31,7 +31,7 @@
           {% endif %}
 
           {% if f.url %}
-            <p><a href="{{ f.url | relative_url }}" class="btn {{ f.btn_class }}"{% if img.rel %} rel="{{ img.rel }}"{% endif %}>{{ f.btn_label | default: site.data.ui-text[site.locale].more_label | default: "Learn More" }}</a></p>
+            <p><a href="{{ f.url | relative_url }}" class="btn {{ f.btn_class }}"{% if f.rel %} rel="{{ f.rel }}"{% endif %}>{{ f.btn_label | default: site.data.ui-text[site.locale].more_label | default: "Learn More" }}</a></p>
           {% endif %}
         </div>
       </div>

--- a/_includes/feature_row
+++ b/_includes/feature_row
@@ -31,7 +31,7 @@
           {% endif %}
 
           {% if f.url %}
-            <p><a href="{{ f.url | relative_url }}" class="btn {{ f.btn_class }}">{{ f.btn_label | default: site.data.ui-text[site.locale].more_label | default: "Learn More" }}</a></p>
+            <p><a href="{{ f.url | relative_url }}" class="btn {{ f.btn_class }}"{% if img.rel %} rel="{{ img.rel }}"{% endif %}>{{ f.btn_label | default: site.data.ui-text[site.locale].more_label | default: "Learn More" }}</a></p>
           {% endif %}
         </div>
       </div>

--- a/_includes/gallery
+++ b/_includes/gallery
@@ -20,6 +20,7 @@
   {% for img in gallery %}
     {% if img.url %}
       <a href="{{ img.url | relative_url }}"
+        {% if img.rel %}rel="{{ img.rel }}"{% endif %}
         {% if img.title %}title="{{ img.title }}"{% endif %}>
           <img src="{{ img.image_path | relative_url }}"
                alt="{% if img.alt %}{{ img.alt }}{% endif %}">

--- a/docs/_docs/14-helpers.md
+++ b/docs/_docs/14-helpers.md
@@ -79,7 +79,8 @@ To place a gallery add the necessary YAML Front Matter.
 
 | Name           | Required     | Description                                                                                                           |
 | -------------- | ------------ | --------------------------------------------------------------------------------------------------------------------- |
-| **url**        | Optional     | URL to link gallery image to (eg. a larger detail image).                                                             |
+| **url**        | Optional     | URL to link gallery image to (eg. a larger detail image or an external link).                                         |
+| **rel**        | Optional     | Makes it possible to specify rel-attribute for the url.                                                               |
 | **image_path** | **Required** | Full path to image eg: `/assets/images/filename.jpg`. Use absolute URLS for those hosted externally.                  |
 | **alt**        | Optional     | Alternate text for image.                                                                                             |
 | **title**      | Optional     | Title text for image. Will display as a caption in a Magnific Popup overlay when linked to a larger image with `url`. |
@@ -134,6 +135,7 @@ To add a feature row containing three content blocks with text and image, add th
 | **title**         | Optional     | Content block title.                                                                                 |                                    |
 | **excerpt**       | Optional     | Content block excerpt text. Markdown is allowed.                                                     |                                    |
 | **url**           | Optional     | URL that the button should link to.                                                                  |                                    |
+| **rel**           | Optional     | Makes it possible to specify rel-attribute for the url.                                              |                                    |
 | **btn_label**     | Optional     | Button text label.                                                                                   | `more_label` in UI Text data file. |
 | **btn_class**     | Optional     | Button style. See [utility classes]({{ "/docs/utility-classes/#buttons"                              | relative_url }}) for options.      | `btn` |
 


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - Read the contributing document at https://github.com/mmistakes/minimal-mistakes#contributing
-->

<!--
  Choose one of the following by uncommenting it:
-->

<!-- This is a bug fix. -->
This is an enhancement or feature.
<!-- This is a documentation change. -->

## Summary

When having external links it is useful to be able to specify the rel-attribute. This makes it possible for `feature_row` and `gallery`.

<!--
  Provide a description of what your pull request changes.
-->

## Context

<!--
  Is this related to any GitHub issue(s)?
-->