### PR TITLE
Enable toc sidebar scrolling

### DIFF
--- a/_sass/minimal-mistakes/_navigation.scss
+++ b/_sass/minimal-mistakes/_navigation.scss
@@ -201,7 +201,7 @@
     }
   }
 
-  img{
+  img {
     -webkit-transition: none;
     transition: none;
   }

--- a/_sass/minimal-mistakes/_navigation.scss
+++ b/_sass/minimal-mistakes/_navigation.scss
@@ -200,7 +200,7 @@
       margin-left: 0;
     }
   }
-  
+
   img{
     -webkit-transition: none;
     transition: none;
@@ -572,18 +572,24 @@
   }
 }
 
-.sidebar__right.sticky > .toc > .toc__menu {
-  overflow-y: auto;
-  scrollbar-width: thin;
-  max-height: calc(100vh - 7em);
-}
-.sidebar__right.sticky > .toc > .toc__menu::-webkit-scrollbar {
-  width: 8px;
-}
-.sidebar__right.sticky > .toc > .toc__menu::-webkit-scrollbar-track {
-  background: #F0F0F0;
-}
-.sidebar__right.sticky > .toc > .toc__menu::-webkit-scrollbar-thumb {
-  background-color: #CDCDCD;
-  border: 1px solid #F0F0F0;
+.sidebar__right {
+  &.sticky {
+    .toc {
+      .toc__menu {
+        overflow-y: auto;
+        scrollbar-width: thin;
+        max-height: calc(100vh - 7em);
+        &::-webkit-scrollbar {
+          width: 8px;
+        }
+        &::-webkit-scrollbar-track {
+          background: #F0F0F0;
+        }
+        &::-webkit-scrollbar-thumb {
+          background-color: #CDCDCD;
+          border: 1px solid #F0F0F0;
+        }
+      }
+    }
+  }
 }

--- a/_sass/minimal-mistakes/_navigation.scss
+++ b/_sass/minimal-mistakes/_navigation.scss
@@ -571,3 +571,19 @@
     padding-left: 3.25rem
   }
 }
+
+.sidebar__right.sticky > .toc > .toc__menu {
+  overflow-y: auto;
+  scrollbar-width: thin;
+  max-height: calc(100vh - 7em);
+}
+.sidebar__right.sticky > .toc > .toc__menu::-webkit-scrollbar {
+  width: 8px;
+}
+.sidebar__right.sticky > .toc > .toc__menu::-webkit-scrollbar-track {
+  background: #F0F0F0;
+}
+.sidebar__right.sticky > .toc > .toc__menu::-webkit-scrollbar-thumb {
+  background-color: #CDCDCD;
+  border: 1px solid #F0F0F0;
+}

--- a/_sass/minimal-mistakes/_navigation.scss
+++ b/_sass/minimal-mistakes/_navigation.scss
@@ -571,25 +571,3 @@
     padding-left: 3.25rem
   }
 }
-
-.sidebar__right {
-  &.sticky {
-    .toc {
-      .toc__menu {
-        overflow-y: auto;
-        scrollbar-width: thin;
-        max-height: calc(100vh - 7em);
-        &::-webkit-scrollbar {
-          width: 8px;
-        }
-        &::-webkit-scrollbar-track {
-          background: #F0F0F0;
-        }
-        &::-webkit-scrollbar-thumb {
-          background-color: #CDCDCD;
-          border: 1px solid #F0F0F0;
-        }
-      }
-    }
-  }
-}

--- a/_sass/minimal-mistakes/_sidebar.scss
+++ b/_sass/minimal-mistakes/_sidebar.scss
@@ -93,18 +93,7 @@
       .toc {
         .toc__menu {
           overflow-y: auto;
-          scrollbar-width: thin;
           max-height: calc(100vh - 7em);
-          &::-webkit-scrollbar {
-            width: 8px;
-          }
-          &::-webkit-scrollbar-track {
-            background: #F0F0F0;
-          }
-          &::-webkit-scrollbar-thumb {
-            background-color: #CDCDCD;
-            border: 1px solid #F0F0F0;
-          }
         }
       }
     }

--- a/_sass/minimal-mistakes/_sidebar.scss
+++ b/_sass/minimal-mistakes/_sidebar.scss
@@ -89,6 +89,24 @@
       position: sticky;
       top: 2em;
       float: right;
+
+      .toc {
+        .toc__menu {
+          overflow-y: auto;
+          scrollbar-width: thin;
+          max-height: calc(100vh - 7em);
+          &::-webkit-scrollbar {
+            width: 8px;
+          }
+          &::-webkit-scrollbar-track {
+            background: #F0F0F0;
+          }
+          &::-webkit-scrollbar-thumb {
+            background-color: #CDCDCD;
+            border: 1px solid #F0F0F0;
+          }
+        }
+      }
     }
   }
 


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - Read the contributing document at https://github.com/mmistakes/minimal-mistakes#contributing
-->

<!--
  Choose one of the following by uncommenting it:
-->

<!-- This is a bug fix. -->
This is an enhancement or feature.
<!-- This is a documentation change. -->

## Summary

<!--
  Provide a description of what your pull request changes.
-->

Enable Table of Content sidebar scrolling as mentioned in issue #1851

This can be achieved by simply adding the followings in `_navigation.scss`:

```css
.sidebar__right.sticky > .toc > .toc__menu {
  overflow-y: auto;
  max-height: calc(100vh - 7em);
}
```

When the toc sidebar is not sticky, this rule will not apply. While if the toc sidebar is sticky (`.sticky`), the `toc_menu`'s height will be limited, and the content will be scrollable with a thin-width scrollbar. I use `max-height` instead of `height` to ensure that short TOCs will not be affected by this rule.

Other scrollbar CSS rules is just for making the scrollbar thin in Chrome/Firefox/... If the default wide scrollbar is not preferred, I can simply remove those style rules and keep the 4 lines above.

### Before

![image](https://user-images.githubusercontent.com/20457146/110819496-35f1ab80-82c9-11eb-9919-38a94573b048.png)

### After

![image](https://user-images.githubusercontent.com/20457146/110819615-4f92f300-82c9-11eb-8172-0bc26fed37d4.png)

## Context

<!--
  Is this related to any GitHub issue(s)?
-->

- #1840 
- #1851 
