### PR TITLE
Color notices based on skin colors instead of fixed values

### DIFF
--- a/_sass/minimal-mistakes/_notices.scss
+++ b/_sass/minimal-mistakes/_notices.scss
@@ -13,11 +13,11 @@
 @mixin notice($notice-color) {
   margin: 2em 0 !important;  /* override*/
   padding: 1em;
-  color: $dark-gray;
+  color: $text-color;
   font-family: $global-font-family;
   font-size: $type-size-6 !important;
   text-indent: initial; /* override*/
-  background-color: mix(#fff, $notice-color, 90%);
+  background-color: mix($background-color, $notice-color, 90%);
   border-radius: $border-radius;
   box-shadow: 0 1px 1px rgba($notice-color, 0.25);
 
@@ -54,7 +54,7 @@
   }
 
   code {
-    background-color: mix(#fff, $notice-color, 95%)
+    background-color: mix($background-color, $notice-color, 95%)
   }
 
 	pre code {

--- a/_sass/minimal-mistakes/_notices.scss
+++ b/_sass/minimal-mistakes/_notices.scss
@@ -17,7 +17,7 @@
   font-family: $global-font-family;
   font-size: $type-size-6 !important;
   text-indent: initial; /* override*/
-  background-color: mix($background-color, $notice-color, 90%);
+  background-color: mix($background-color, $notice-color, $notice-background-mix);
   border-radius: $border-radius;
   box-shadow: 0 1px 1px rgba($notice-color, 0.25);
 
@@ -46,15 +46,15 @@
   }
 
   a {
-    color: $notice-color;
+    color: mix(#000, $notice-color, 10%);
 
     &:hover {
-      color: mix(#000, $notice-color, 40%);
+      color: mix(#000, $notice-color, 50%);
     }
   }
 
   code {
-    background-color: mix($background-color, $notice-color, 95%)
+    background-color: mix($background-color, $notice-color, $code-notice-background-mix)
   }
 
 	pre code {

--- a/_sass/minimal-mistakes/_variables.scss
+++ b/_sass/minimal-mistakes/_variables.scss
@@ -118,6 +118,10 @@ $masthead-link-color: $primary-color !default;
 $masthead-link-color-hover: mix(#000, $primary-color, 25%) !default;
 $navicon-link-color-hover: mix(#fff, $primary-color, 75%) !default;
 
+/* notices */
+$notice-background-mix: 80% !default;
+$code-notice-background-mix: 90% !default;
+
 /* syntax highlighting (base16) */
 $base00: #263238 !default;
 $base01: #2e3c43 !default;

--- a/_sass/minimal-mistakes/skins/_aqua.scss
+++ b/_sass/minimal-mistakes/skins/_aqua.scss
@@ -28,3 +28,7 @@ $link-color-hover           : mix(#000, $link-color, 25%) !default;
 $link-color-visited         : mix(#fff, $link-color, 25%) !default;
 $masthead-link-color        : $primary-color !default;
 $masthead-link-color-hover  : mix(#000, $primary-color, 25%) !default;
+
+/* notices */
+$notice-background-mix: 90% !default;
+$code-notice-background-mix: 95% !default;

--- a/_sass/minimal-mistakes/skins/_dark.scss
+++ b/_sass/minimal-mistakes/skins/_dark.scss
@@ -18,10 +18,6 @@ $masthead-link-color: $text-color !default;
 $masthead-link-color-hover: mix(#000, $text-color, 20%) !default;
 $navicon-link-color-hover: mix(#000, $background-color, 30%) !default;
 
-/* notices */
-$notice-background-mix: 90% !default;
-$code-notice-background-mix: 95% !default;
-
 .author__urls.social-icons i,
 .author__urls.social-icons .svg-inline--fa,
 .page__footer-follow .social-icons i,

--- a/_sass/minimal-mistakes/skins/_dark.scss
+++ b/_sass/minimal-mistakes/skins/_dark.scss
@@ -18,6 +18,10 @@ $masthead-link-color: $text-color !default;
 $masthead-link-color-hover: mix(#000, $text-color, 20%) !default;
 $navicon-link-color-hover: mix(#000, $background-color, 30%) !default;
 
+/* notices */
+$notice-background-mix: 90% !default;
+$code-notice-background-mix: 95% !default;
+
 .author__urls.social-icons i,
 .author__urls.social-icons .svg-inline--fa,
 .page__footer-follow .social-icons i,

--- a/_sass/minimal-mistakes/skins/_neon.scss
+++ b/_sass/minimal-mistakes/skins/_neon.scss
@@ -18,6 +18,10 @@ $masthead-link-color: $text-color !default;
 $masthead-link-color-hover: mix(#000, $text-color, 20%) !default;
 $navicon-link-color-hover: mix(#000, $background-color, 30%) !default;
 
+/* notices */
+$notice-background-mix: 90% !default;
+$code-notice-background-mix: 95% !default;
+
 /* neon syntax highlighting (base16) */
 $base00: #ffffff !default;
 $base01: #e0e0e0 !default;

--- a/_sass/minimal-mistakes/skins/_plum.scss
+++ b/_sass/minimal-mistakes/skins/_plum.scss
@@ -18,6 +18,10 @@ $masthead-link-color: $text-color !default;
 $masthead-link-color-hover: mix(#000, $text-color, 20%) !default;
 $navicon-link-color-hover: mix(#000, $background-color, 30%) !default;
 
+/* notices */
+$notice-background-mix: 70% !default;
+$code-notice-background-mix: 80% !default;
+
 /* plum syntax highlighting (base16) */
 $base00: #ffffff !default;
 $base01: #e0e0e0 !default;

--- a/_sass/minimal-mistakes/skins/_sunrise.scss
+++ b/_sass/minimal-mistakes/skins/_sunrise.scss
@@ -20,6 +20,9 @@ $masthead-link-color: $text-color !default;
 $masthead-link-color-hover: mix(#000, $text-color, 20%) !default;
 $navicon-link-color-hover: mix(#000, $background-color, 30%) !default;
 
+/* notices */
+$notice-background-mix: 75% !default;
+
 /* sunrise syntax highlighting (base16) */
 $base00: #1d1f21 !default;
 $base01: #282a2e !default;


### PR DESCRIPTION
This is an enhancement or feature.

## Summary

This PR replaces the fixed color values of `$dark-gray` and `#fff` used to determine notice foreground and background colors with `$text-color` and  `$background-color`, respectively.  The old values are the defaults for the theme, so the default skin is unaffected.

## Context

I almost always use dark themes for my sites, and notices are very glaring as is:
![image](https://user-images.githubusercontent.com/8538570/112417143-54aa6600-8cfd-11eb-8d5c-59e64e1b2288.png)

With this PR, it is much easier on the eyes, and the background color changes are more obvious.

<details><summary>Screenshots of all prepackaged skins</summary>

### `minimal_mistakes_skin: "default"`:
![image](https://user-images.githubusercontent.com/8538570/112417329-bf5ba180-8cfd-11eb-9704-b818c68fca08.png)

### minimal_mistakes_skin: "air"
![image](https://user-images.githubusercontent.com/8538570/112417409-f92ca800-8cfd-11eb-985f-cac9bba7b71e.png)

### minimal_mistakes_skin: "aqua"
![image](https://user-images.githubusercontent.com/8538570/112417441-08135a80-8cfe-11eb-97bf-f0e3ae7c7d3f.png)

### minimal_mistakes_skin: "contrast"
![image](https://user-images.githubusercontent.com/8538570/112417466-15c8e000-8cfe-11eb-902f-e51890179057.png)

### `minimal_mistakes_skin: "dark"`:
![image](https://user-images.githubusercontent.com/8538570/112417260-83c0d780-8cfd-11eb-8eee-8b057d24da74.png)

### minimal_mistakes_skin: "dirt"
![image](https://user-images.githubusercontent.com/8538570/112417488-224d3880-8cfe-11eb-88fb-9aa540f064dd.png)

### minimal_mistakes_skin: "neon"
![image](https://user-images.githubusercontent.com/8538570/112417517-3133eb00-8cfe-11eb-9d4d-7c383374ec03.png)

### minimal_mistakes_skin: "mint"
![image](https://user-images.githubusercontent.com/8538570/112417545-3d1fad00-8cfe-11eb-89ed-f46da8e82cf2.png)

### minimal_mistakes_skin: "plum"
![image](https://user-images.githubusercontent.com/8538570/112417574-4b6dc900-8cfe-11eb-8c9a-bc9d998c1540.png)

### minimal_mistakes_skin: "sunrise"
![image](https://user-images.githubusercontent.com/8538570/112417614-56285e00-8cfe-11eb-8dfe-e7f37db2348e.png)

</details>