### PR TITLE
Add pinned post to home page, with example

### DIFF
--- a/_layouts/art_gallery_index.html
+++ b/_layouts/art_gallery_index.html
@@ -1,0 +1,17 @@
+---
+layout: archive
+# This page is used for the main index of galleries
+---
+
+<div>
+	<ul class="small-block-grid-4">
+        {% for gallery in page.galleries %}
+        <li>
+        <a href="{{ gallery['link'] }}">
+            <img class="gallery-best-image" src="{{ gallery['link'] }}/thumbs/front_{{ gallery['best_image'] }}">
+        </a>
+        <h3><a href="{{ gallery['link'] }}">{{ gallery["title"] }}</a></h3>
+        </li>
+        {% endfor %}
+	</ul>
+</div>

--- a/_layouts/art_gallery_page.html
+++ b/_layouts/art_gallery_page.html
@@ -1,0 +1,23 @@
+---
+layout: archive
+# individual pages for each gallery
+header:
+    title: Some Title
+    background-color: "#6B8A78"
+---
+<div>
+      	<ul class="clearing-thumbs small-block-grid-4" data-clearing>
+		{% for image in page.images %}
+        <li><a href="{{ image }}">
+        	{% if page.captions[image] == nil %}
+        	<img data-caption="<a class='clearing-link' href='/contact/'>Ask me about this work</a>" src="thumbs/{{ image }}">
+            {% else %}
+        	<img data-caption="{{ page.captions[image] }}.  <a class='clearing-link' href='/contact/'>Ask me about this work</a>" src="thumbs/{{ image }}" alt="{{ page.captions[image] }}" title="{{ page.captions[image] }}">
+            {% endif %}
+        </a></li>
+		{% endfor %}
+	</ul>
+	<div id="spinner"></div>
+</div>
+
+{{ page.description }}

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -2,6 +2,23 @@
 layout: archive
 ---
 
+{% if page.url == "/" %}
+  {% assign entries_layout = page.entries_layout | default: 'list' %}
+  {% assign print_header = true %}
+  <div class="entries-{{ entries_layout }}">
+    {% assign posts = site.posts %}
+    {% for post in posts %}
+      {% if post.pinned %}
+        {% if print_header %}
+          <h2 class="archive__subtitle"><i class="fas fa-thumbtack"></i> Pinned Posts</h2>
+          {% assign print_header = false %}
+        {% endif %}
+        {% include archive-single.html type=entries_layout %}
+      {% endif %}
+    {% endfor %}
+  </div>
+ {% endif %}
+  
 {{ content }}
 
 <h3 class="archive__subtitle">{{ site.data.ui-text[site.locale].recent_posts | default: "Recent Posts" }}</h3>

--- a/test/_posts/2010-01-09-pinned-post.md
+++ b/test/_posts/2010-01-09-pinned-post.md
@@ -1,0 +1,11 @@
+---
+title: "Post: Pinned"
+categories:
+  - Post Formats
+tags:
+  - Post Formats
+pinned: true
+---
+
+This is a post that is pinned to the top of the front page. To enable this feature in your own posts,
+put the value ```pinned: true``` in the front matter of your posts.


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - Read the contributing document at https://github.com/mmistakes/minimal-mistakes#contributing
-->

<!--
  Choose one of the following by uncommenting it:
-->

<!-- This is a bug fix. -->
This is an enhancement or feature.
<!-- This is a documentation change. -->

## Summary

<!--
  Provide a description of what your pull request changes.
-->

Adds the ability to 'pin' a post to the top of the front page, such as a welcome message or the T&Cs for the site. Adds a
new boolean front matter value of 'pinned' that triggers layouts/home.html to search for pinned posts. Includes a sample
of a pinned post.

Pinned posts will also show up in recents as they may or may not be on page 1 if paginated.

## Context

<!--
  Is this related to any GitHub issue(s)?
-->

Not related to a Github issue. This was a feature that I wanted for my hobby site: https://my72mgb.com
