### PR TITLE
Fix issue where post.excerpt was not being used for Open Graph descri…

### DIFF
--- a/_includes/seo.html
+++ b/_includes/seo.html
@@ -20,7 +20,7 @@
   {%- assign canonical_url = page.url | replace: "index.html", "" | absolute_url %}
 {% endif %}
 
-{%- assign seo_description = page.description | default: page.excerpt | default: site.description -%}
+{%- assign seo_description = page.description | default: page.excerpt | default: post.excerpt | default: site.description -%}
 {%- if seo_description -%}
   {%- assign seo_description = seo_description | markdownify | strip_html | newline_to_br | strip_newlines | replace: '<br />', ' ' | escape_once | strip -%}
 {%- endif -%}


### PR DESCRIPTION
This is a bug fix.

## Summary

This fixes this issue where Open Graph description (og:description) on posts uses the site description instead of the post.excerpt.
See issue https://github.com/mmistakes/minimal-mistakes/issues/2964