### PR TITLE
Remove H2 as it is not important to site structure

### DIFF
--- a/_includes/skip-links.html
+++ b/_includes/skip-links.html
@@ -1,5 +1,4 @@
 <nav class="skip-links">
-  <h2 class="screen-reader-text">{{ site.data.ui-text[site.locale].skip_links | default: 'Skip links' }}</h2>
   <ul>
     <li><a href="#site-nav" class="screen-reader-shortcut">{{ site.data.ui-text[site.locale].skip_primary_nav | default: 'Skip to primary navigation' }}</a></li>
     <li><a href="#main" class="screen-reader-shortcut">{{ site.data.ui-text[site.locale].skip_content | default: 'Skip to content' }}</a></li>


### PR DESCRIPTION
This should not use a H2, as that is not an important headline, and thus a H2 here would probably hurt in page SEO.

<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - Read the contributing document at https://github.com/mmistakes/minimal-mistakes#contributing
-->

<!--
  Choose one of the following by uncommenting it:
-->

<!-- This is a bug fix. -->
<!-- This is an enhancement or feature. -->
<!-- This is a documentation change. -->

## Summary

<!--
  Provide a description of what your pull request changes.
-->

## Context

<!--
  Is this related to any GitHub issue(s)?
-->