### PR TITLE
Remove IE9 flexbox fallback

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -18,21 +18,6 @@
 <link rel="preload" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@5/css/all.min.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
 <noscript><link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@5/css/all.min.css"></noscript>
 
-<!--[if IE]>
-  <style>
-    /* old IE unsupported flexbox fixes */
-    .greedy-nav .site-title {
-      padding-right: 3em;
-    }
-    .greedy-nav button {
-      position: absolute;
-      top: 0;
-      right: 0;
-      height: 100%;
-    }
-  </style>
-<![endif]-->
-
 {% if site.head_scripts %}
   {% for script in site.head_scripts %}
     <script src="{{ script | relative_url }}"></script>


### PR DESCRIPTION
## Summary

Save some bytes in the HTML for all users by removing the fallback inline CSS.

## Context

IE9 is absolutely, completely, totally dead. it's marketshare is less than 0.1%.

REF: https://caniuse.com/usage-table