### PR TITLE
Add instructions on how to unminify main.js for easier browser debugging

### DIFF
--- a/docs/_docs/17-javascript.md
+++ b/docs/_docs/17-javascript.md
@@ -67,11 +67,14 @@ If all goes well, running `npm run build:js` will compress/concatenate `_main.js
 
 ## Debugging
 The minified Javascript is harder to debug in the browser than the raw source. To stop the minification and just bundle all the Javascript as-is; open up `package.json` and edit the value `scripts.uglify` from:
+
 ```json
   "scripts": {
     "uglify": "uglifyjs [...] -c -m -o assets/js/main.min.js",
 ```
+
 to simply concatenating the files:
+
 ```json
   "scripts": {
     "uglify": "cat [...] > assets/js/main.min.js",

--- a/docs/_docs/17-javascript.md
+++ b/docs/_docs/17-javascript.md
@@ -64,3 +64,15 @@ To get started:
 {: .notice--warning}
 
 If all goes well, running `npm run build:js` will compress/concatenate `_main.js` and all plugin scripts into `main.min.js`.
+
+## Debugging
+The minified Javascript is harder to debug in the browser than the raw source. To stop the minification and just bundle all the Javascript as-is; open up `package.json` and edit the value `scripts.uglify` from:
+```json
+  "scripts": {
+    "uglify": "uglifyjs [...] -c -m -o assets/js/main.min.js",
+```
+to simply concatenating the files:
+```json
+  "scripts": {
+    "uglify": "cat [...] > assets/js/main.min.js",
+```


### PR DESCRIPTION
This is a documentation change.

## Summary
Add instructions on how to unminify the `main.min.js` for easier browser debugging.



## Context
I'm having issues looking very much the same like already reported in #2664 (that the greedy-nav is not consistent in how it hides/shows navigation items), even though the fix for this issue is included in the theme release that I'm using.

I've nailed it down to that the browser reports the wrong `outerWidth()` of the navigation items some times and thus the `jquery.greedy-navigation.js` logic will compute the wrong thing as the calculations are based on wrong values. From here I've not gotten further though on how/why the browser on some page loads reports the wrong element widths.

Anyways to figure this out I had the need to unminify the main JavaScript file to set some debugger breakpoints in my browser. I just wanted to share back to the documentation on how one can easily prevent the minification.

Maybe there's even a better way? This is what made it for me though.