### PR TITLE
Feature: Add target attribute for navigation link

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 *~
 *.sw[p_]
 
+# IntelliJ IDEA
+*.idea
+
 # Sublime Text
 *.sublime-project
 *.sublime-workspace

--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -14,7 +14,11 @@
         <ul class="visible-links">
           {%- for link in site.data.navigation.main -%}
             <li class="masthead__menu-item">
-              <a href="{{ link.url | relative_url }}"{% if link.description %} title="{{ link.description }}"{% endif %}>{{ link.title }}</a>
+              <a
+                href="{{ link.url | relative_url }}"
+                {% if link.description %} title="{{ link.description }}"{% endif %}
+                {% if link.target %} target="{{ link.target }}"{% endif %}
+              >{{ link.title }}</a>
             </li>
           {%- endfor -%}
         </ul>

--- a/docs/_docs/07-navigation.md
+++ b/docs/_docs/07-navigation.md
@@ -30,6 +30,7 @@ main:
     url: /collection-archive/
   - title: "External Link"
     url: https://google.com
+    target: _blank
 ```
 
 Which will give you a responsive masthead similar to this:


### PR DESCRIPTION
This PR adds `target` attribute for links in the navigation menu.

P.S. I think may be add `attributes` property for more flexible configuration these link?