### PR TITLE
Fixed a grammar error in the german translation

### DIFF
--- a/_data/ui-text.yml
+++ b/_data/ui-text.yml
@@ -496,7 +496,7 @@ de: &DEFAULT_DE
   toc_label                  : "Auf dieser Seite"
   ext_link_label             : "Direkter Link"
   less_than                  : "weniger als"
-  minute_read                : "Minuten zum lesen"
+  minute_read                : "Minuten zum Lesen"
   share_on_label             : "Teilen auf"
   meta_label                 :
   tags_label                 : "Tags:"


### PR DESCRIPTION
This is a bug fix.

## Summary

Fixed a small grammar error in the german translation
