### PR TITLE
fix: change heading tag of related posts section from `h4` to `h2` for SEO enhancement

### DIFF
--- a/_layouts/single.html
+++ b/_layouts/single.html
@@ -65,7 +65,7 @@ layout: default
   {% comment %}<!-- only show related on a post page when `related: true` -->{% endcomment %}
   {% if page.id and page.related and site.related_posts.size > 0 %}
     <div class="page__related">
-      <h4 class="page__related-title">{{ site.data.ui-text[site.locale].related_label | default: "You May Also Enjoy" }}</h4>
+      <h2 class="page__related-title">{{ site.data.ui-text[site.locale].related_label | default: "You May Also Enjoy" }}</h2>
       <div class="grid__wrapper">
         {% for post in site.related_posts limit:4 %}
           {% include archive-single.html type="grid" %}
@@ -75,7 +75,7 @@ layout: default
   {% comment %}<!-- otherwise show recent posts if no related when `related: true` -->{% endcomment %}
   {% elsif page.id and page.related %}
     <div class="page__related">
-      <h4 class="page__related-title">{{ site.data.ui-text[site.locale].related_label | default: "You May Also Enjoy" }}</h4>
+      <h2 class="page__related-title">{{ site.data.ui-text[site.locale].related_label | default: "You May Also Enjoy" }}</h2>
       <div class="grid__wrapper">
         {% for post in site.posts limit:4 %}
           {% if post.id == page.id %}

--- a/docs/_layouts/single.html
+++ b/docs/_layouts/single.html
@@ -73,7 +73,7 @@ layout: default
               data-ad-format="auto"
               data-full-width-responsive="true"></ins>
       </div>
-      <h4 class="page__related-title">{{ site.data.ui-text[site.locale].related_label | default: "You May Also Enjoy" }}</h4>
+      <h2 class="page__related-title">{{ site.data.ui-text[site.locale].related_label | default: "You May Also Enjoy" }}</h2>
       <div class="grid__wrapper">
         {% for post in site.related_posts limit:4 %}
           {% include archive-single.html type="grid" %}
@@ -83,7 +83,7 @@ layout: default
   {% comment %}<!-- otherwise show recent posts if no related when `related: true` -->{% endcomment %}
   {% elsif page.id and page.related %}
     <div class="page__related">
-      <h4 class="page__related-title">{{ site.data.ui-text[site.locale].related_label | default: "You May Also Enjoy" }}</h4>
+      <h2 class="page__related-title">{{ site.data.ui-text[site.locale].related_label | default: "You May Also Enjoy" }}</h2>
       <div class="grid__wrapper">
         {% for post in site.posts limit:4 %}
           {% if post.id == page.id %}


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - Read the contributing document at https://github.com/mmistakes/minimal-mistakes#contributing
-->

<!--
  Choose one of the following by uncommenting it:
-->

<!-- This is a bug fix. -->
This is an enhancement or feature.
<!-- This is a documentation change. -->

## Summary

<!--
  Provide a description of what your pull request changes.
-->
This PR is about changing the heading tag of related posts section from `h4` to `h2` for SEO enhancement. I have implemented the same on my website in [PR](https://github.com/kulbhushanchand/kulbhushanchand.github.io/commit/835332069f83fda3fff2eb75456d03ac5756c7cd) and working [demo](https://kulbhushanchand.github.io/website-is-up-and-ready/)
## Context

<!--
  Is this related to any GitHub issue(s)?
-->
With reference to your comment on my post at https://github.com/mmistakes/minimal-mistakes/discussions/3040#discussioncomment-1010824

Since you have already provided the relevant font size, so any style change may not be required. https://github.com/mmistakes/minimal-mistakes/blob/3c075fe76b0971f3ccc63c6940b63306d6100fb2/_sass/minimal-mistakes/_page.scss#L529


