### PR TITLE
Feature/related by tags and categories

### DIFF
--- a/_layouts/single.html
+++ b/_layouts/single.html
@@ -64,12 +64,46 @@ layout: default
     {% endif %}
   </article>
 
-  {% comment %}<!-- only show related on a post page when `related: true` -->{% endcomment %}
-  {% if page.id and page.related and site.related_posts.size > 0 %}
+  {% comment %}<!-- only show tag/category related posts page when `related: true` -->{% endcomment %}
+  {% assign related_limit = page.related_limit | default: site.related_limit | default: 4 %}
+  {% assign related_threshold = page.related_threshold | default: site.related_threshold | default: 0 %}
+  {% if page.id and page.related and related_threshold > 0 %}
     <div class="page__related">
       <h2 class="page__related-title">{{ site.data.ui-text[site.locale].related_label | default: "You May Also Enjoy" }}</h2>
       <div class="grid__wrapper">
-        {% for post in site.related_posts limit:4 %}
+        {% assign include_count = 0 %}
+        {% assign all = site.documents | concat: site.pages %}
+        {% for post in all %}
+          {% if post.id == page.id %}
+            {% continue %}
+          {% endif %}
+          {% assign related_count = 0 %}
+          {% for tag in post.tags %}
+            {% if page.tag == tag or page.tags contains tag %}
+              {% assign related_count = related_count | plus: 1 %}
+            {% endif %}
+          {% endfor %}
+          {% for cat in post.categories %}
+            {% if page.category == cat or page.categories contains cat %}
+              {% assign related_count = related_count | plus: 1 %}
+            {% endif %}
+          {% endfor %}
+          {% if related_count >= related_threshold %}
+            {% include archive-single.html type="grid" %}
+            {% assign include_count = include_count | plus: 1 %}
+            {% if include_count >= related_limit %}
+              {% break %}
+            {% endif %}
+          {% endif %}
+        {% endfor %}
+      </div>
+    </div>
+  {% comment %}<!-- only show related on a post page when `related: true` -->{% endcomment %}
+  {% elsif page.id and page.related and site.related_posts.size > 0 %}
+    <div class="page__related">
+      <h2 class="page__related-title">{{ site.data.ui-text[site.locale].related_label | default: "You May Also Enjoy" }}</h2>
+      <div class="grid__wrapper">
+        {% for post in site.related_posts limit:related_limit %}
           {% include archive-single.html type="grid" %}
         {% endfor %}
       </div>
@@ -79,7 +113,7 @@ layout: default
     <div class="page__related">
       <h2 class="page__related-title">{{ site.data.ui-text[site.locale].related_label | default: "You May Also Enjoy" }}</h2>
       <div class="grid__wrapper">
-        {% for post in site.posts limit:4 %}
+        {% for post in site.posts limit:related_limit %}
           {% if post.id == page.id %}
             {% continue %}
           {% endif %}

--- a/assets/js/_main.js
+++ b/assets/js/_main.js
@@ -84,7 +84,7 @@ $(document).ready(function() {
   // add lightbox class to all image links
   $(
     "a[href$='.jpg'],a[href$='.jpeg'],a[href$='.JPG'],a[href$='.png'],a[href$='.gif'],a[href$='.webp']"
-  ).has("> img").addClass("image-popup");;
+  ).has("> img").addClass("image-popup");
 
   // Magnific-Popup options
   $(".image-popup").magnificPopup({

--- a/docs/_docs/05-configuration.md
+++ b/docs/_docs/05-configuration.md
@@ -1035,6 +1035,23 @@ paginate_path: /recent/page:num/
 **Please note:** When using Jekyll's default [pagination plugin](https://jekyllrb.com/docs/pagination/) `paginator.posts` can only be called once. If you're looking for something more powerful that can paginate category, tag, and collection pages I suggest [**jekyll-paginate-v2**](https://github.com/sverrirs/jekyll-paginate-v2).
 {: .notice--info}
 
+### Related Pages
+
+By default Jekyll sets the `site.related_posts` to the most recent posts. Minimal mistakes selects from these when `site.related_posts.size > 0`, falling back to `site.posts` if not.
+
+The `single` layout can also relate pages by tags and categories. This works across all collections (including posts). Set the `related_threshold` value to the number of matching tags and/or categories required to relate a page. For example, setting `related_threshold: 2` requires 2 matching tags and/or categories to include a page in the related section (2 tags, 2 categories or 1 of each).
+
+By default 4 related posts are included by the module. This can be overridden by setting a `related_limit` value.
+
+Both `related_threshold` and `related_limit` can be defined at the site level, under `defaults:` in `_config.yml` or in an individual page's front matter.
+
+For example:
+
+```yaml
+related_threshold: 2  # Match 2 or more tags and/or categories.
+related_limit: 6      # Include upto 6 related pages (default is 4)
+```
+
 ### Timezone
 
 This sets the timezone environment variable, which Ruby uses to handle time and date creation and manipulation. Any entry from the [IANA Time Zone Database](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) is valid. The default is the local time zone, as set by your operating system.

--- a/docs/_layouts/single.html
+++ b/docs/_layouts/single.html
@@ -62,8 +62,42 @@ layout: default
     {% endif %}
   </article>
 
+  {% comment %}<!-- only show tag/category related posts page when `related: true` -->{% endcomment %}
+  {% assign related_limit = page.related_limit | default: site.related_limit | default: 4 %}
+  {% assign related_threshold = page.related_threshold | default: site.related_threshold | default: 0 %}
+  {% if page.id and page.related and related_threshold > 0 %}
+    <div class="page__related">
+      <h2 class="page__related-title">{{ site.data.ui-text[site.locale].related_label | default: "You May Also Enjoy" }}</h2>
+      <div class="grid__wrapper">
+        {% assign include_count = 0 %}
+        {% assign all = site.documents | concat: site.pages %}
+        {% for post in all %}
+          {% if post.id == page.id %}
+            {% continue %}
+          {% endif %}
+          {% assign related_count = 0 %}
+          {% for tag in post.tags %}
+            {% if page.tag == tag or page.tags contains tag %}
+              {% assign related_count = related_count | plus: 1 %}
+            {% endif %}
+          {% endfor %}
+          {% for cat in post.categories %}
+            {% if page.category == cat or page.categories contains cat %}
+              {% assign related_count = related_count | plus: 1 %}
+            {% endif %}
+          {% endfor %}
+          {% if related_count >= related_threshold %}
+            {% include archive-single.html type="grid" %}
+            {% assign include_count = include_count | plus: 1 %}
+            {% if include_count >= related_limit %}
+              {% break %}
+            {% endif %}
+          {% endif %}
+        {% endfor %}
+      </div>
+    </div> 
   {% comment %}<!-- only show related on a post page when `related: true` -->{% endcomment %}
-  {% if page.id and page.related and site.related_posts.size > 0 %}
+  {% elsif page.id and page.related and site.related_posts.size > 0 %}
     <div class="page__related">
       <div align="center" style="margin: 1em 0;">
         <ins class="adsbygoogle"
@@ -75,7 +109,7 @@ layout: default
       </div>
       <h2 class="page__related-title">{{ site.data.ui-text[site.locale].related_label | default: "You May Also Enjoy" }}</h2>
       <div class="grid__wrapper">
-        {% for post in site.related_posts limit:4 %}
+        {% for post in site.related_posts limit:related_limit %}
           {% include archive-single.html type="grid" %}
         {% endfor %}
       </div>
@@ -85,7 +119,7 @@ layout: default
     <div class="page__related">
       <h2 class="page__related-title">{{ site.data.ui-text[site.locale].related_label | default: "You May Also Enjoy" }}</h2>
       <div class="grid__wrapper">
-        {% for post in site.posts limit:4 %}
+        {% for post in site.posts limit:related_limit %}
           {% if post.id == page.id %}
             {% continue %}
           {% endif %}

--- a/docs/_posts/2012-01-02-layout-related-posts-tags-categories.md
+++ b/docs/_posts/2012-01-02-layout-related-posts-tags-categories.md
@@ -1,0 +1,14 @@
+---
+title: "Layout: Related Posts by Tags/Categories"
+related: true
+related_threshold: 3
+related_limit: 6
+categories:
+  - Layout
+  - Uncategorized
+tags:
+  - related posts
+  - layout
+---
+
+This post has related posts enabled and matching by 3 or more tags and categories, showing up-to 6 pages.


### PR DESCRIPTION
This is an enhancement or feature.

## Summary

Add ability to include related pages by tags and/or categories. With the related_threshold > 0 pages with the matching number of tags and/or categories will be included instead of site.related_posts.

## Context

Not related to any GitHub issue(s).
