### PR TITLE
Use GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -14,7 +14,7 @@ about: "Is something not working as expected?"
     for solutions and to avoid duplication.
   - Ask for help at http://talk.jekyllrb.com/
   
-  After exhausting these suggestions use the format below.
+  If none of the above solved your problem, you can continue below.
 -->
 
 ## Environment
@@ -25,7 +25,7 @@ about: "Is something not working as expected?"
 
   Issues without a link to a public repository or ZIP file will likely go ignored.
   Being able to see your actual files is necessary to troubleshoot, as most 
-  issues stem from invalid/missing YAML Front Matter, a mis-configured _config.sys 
+  issues stem from invalid/missing YAML Front Matter, a mis-configured _config.yml 
   file, or problematic site content. 
 -->
 
@@ -33,7 +33,7 @@ about: "Is something not working as expected?"
 - Ruby gem or remote theme version:
 - Jekyll version:
 - Git repository URL:
-- GitHub Pages hosted (if yes provide URL to site):
+- Hosted on GitHub Pages (if yes provide URL to site):
 - Operating system:
 
 ## Expected behavior
@@ -46,7 +46,7 @@ about: "Is something not working as expected?"
 ## Steps to reproduce the behavior
 
 <!--
-  Describe the steps you took for this problem to exist. Such as: you installed
+  Describe the steps you took for this problem to come up. Such as: you installed
   the theme, customized _config.yml, added your own posts, and started up a 
   Jekyll server locally.
 

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,81 @@
+name: Bug Report
+description: There is something wrong with the theme. 99% of the time you should select Support below.
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Before opening a new issue please:
+
+        - Verify you have the latest versions of Jekyll and Minimal Mistakes
+          installed by running `bundle update`.
+        - Thoroughly read the theme's documentation at
+          https://mmistakes.github.io/minimal-mistakes/docs/quick-start-guide/
+        - Search all issues at https://github.com/mmistakes/minimal-mistakes/issues
+          for solutions and to avoid duplication.
+        - Ask for help at https://talk.jekyllrb.com/
+
+        If none of the above solved your problem, you can continue below.
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: What happened?
+      description: |
+        Please include theme version, Jekyll version, public git repository, whether
+        you are hosting with GitHub Pages, and the operating system you tested with.
+
+        Issues without a link to a public repository or ZIP file will likely go ignored.
+        Being able to see your actual files is necessary to troubleshoot, as most
+        issues stem from invalid/missing YAML Front Matter, a mis-configured _config.yml
+        file, or problematic site content.
+      value: |-
+        - Minimal Mistakes version:
+        - Ruby gem or remote theme version:
+        - Jekyll version:
+        - Git repository URL:
+        - Hosted on GitHub Pages (if yes provide URL to site):
+        - Operating system:
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected behavior
+      description: |
+        Please describe the expected behavior and the actual result you got.
+      placeholder: >
+        What is it you expected to happen? This should be a description of how the
+        functionality you tried to use is supposed to work.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps-to-reproduce
+    attributes:
+      label: Steps to reproduce the behavior
+      description: |
+        Describe the steps you took for this problem to come up. Such as: you installed
+        the theme, customized _config.yml, added your own posts, and started up a
+        Jekyll server locally.
+
+        If an error occurred on GitHub Pages when pushing, please test a local version
+        following these setup instructions:
+        https://help.github.com/articles/setting-up-your-github-pages-site-locally-with-jekyll/
+
+        Then provide a complete log by running `bundle exec jekyll build --trace --verbose`
+        and include this output in the filed issue.
+
+        Screenshots can also be included if they help illustrate a behavior.
+    validations:
+      required: true
+
+  - type: textarea
+    id: other
+    attributes:
+      label: Other
+      description: |
+        Please provide a code repository, gist, code snippet, sample files,
+        screenshots, or anything else you think will aid in reproducing the issue.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Support
+    url: https://github.com/mmistakes/minimal-mistakes/discussions
+    about: Please post your support questions in the Discussions section.

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,25 @@
+name: Documentation
+description: Found a typo or something that needs clarification?
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to open an issue and help make the docs better.
+
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motivation
+      description: |
+        Why should we update our docs?
+    validations:
+      required: true
+
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: Suggestion
+      description: |
+        What should we do instead?
+    validations:
+      required: true


### PR DESCRIPTION
Use [GitHub issue templates](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository) to direct support questions to Discussions.

You can [preview this PR on my fork](https://github.com/iBug/minimal-mistakes/issues/new/choose). I also recommend revising the templates (descriptions / pre-filled text etc.) before/after merging as I feel they could be improved.

P.S. This description should account for a good portion of support questions posted as issues, so I did some rewording on the bug report template. Also I believe "Documentations" would be better renamed to "Feature Request" or "Suggestions", but I lack the background behind the initial choice of this title, so I left it as-is.

<details>
<summary>Screenshot</summary>
<img src="https://user-images.githubusercontent.com/7273074/130785103-963bd032-89f4-4c36-9a8e-3e9ec304fb36.png" />
</details>
