### PR TITLE
Fix broken link

### DIFF
--- a/docs/_docs/05-configuration.md
+++ b/docs/_docs/05-configuration.md
@@ -710,7 +710,7 @@ Formerly known as [Google Webmaster Tools](https://www.google.com/webmasters/too
 
 #### Bing Webmaster Tools
 
-There are several ways to [verify site ownership](https://www.bing.com/webmaster/help/how-to-verify-ownership-of-your-site-afcfefc6) --- the easiest adding an authentication code to your config file.
+There are several ways to [verify site ownership](https://www.bing.com/webmasters/help/add-and-verify-site-12184f8b) --- the easiest adding an authentication code to your config file.
 
 Copy and paste the string inside of `content`:
 


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - Read the contributing document at https://github.com/mmistakes/minimal-mistakes#contributing
-->

<!--
  Choose one of the following by uncommenting it:
-->

<!-- This is a bug fix. -->
<!-- This is an enhancement or feature. -->
This is a documentation change.

## Summary

Link to Bing Webmaster Tools in the [configuration docs](https://mmistakes.github.io/minimal-mistakes/docs/configuration/#bing-webmaster-tools) was broken.

Previous link was [this](https://www.bing.com/webmaster/help/how-to-verify-ownership-of-your-site-afcfefc6), which leads to `page can’t be found` error. Updated to [this new link](https://www.bing.com/webmasters/help/add-and-verify-site-12184f8b) with this commit.

## Context

There are no related GitHub issues for this problem.