### PR TITLE
Fix broken link & Add Baidu site verification

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -73,8 +73,9 @@ google:
 # SEO Related
 google_site_verification :
 bing_site_verification   :
-yandex_site_verification :
 naver_site_verification  :
+yandex_site_verification :
+baidu_site_verification  :
 
 # Social Sharing
 twitter:

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -66,8 +66,9 @@ algolia:
 # SEO Related
 google_site_verification : "UQj93ERU9zgECodaaXgVpkjrFn9UrDMEzVamacSoQ8Y" # Replace this with your ID, or delete
 bing_site_verification   :
-yandex_site_verification :
 naver_site_verification  :
+yandex_site_verification :
+baidu_site_verification  :
 
 # Social Sharing
 twitter:

--- a/docs/_docs/05-configuration.md
+++ b/docs/_docs/05-configuration.md
@@ -807,7 +807,7 @@ facebook:
   username: "michaelrose"  # https://www.facebook.com/michaelrose
 ```
 
-**ProTip:** To debug Open Graph data use [this tool](https://developers.facebook.com/tools/debug/og/object?q=https%3A%2F%2Fmademistakes.com) to test your pages. If content changes aren't reflected you will probably have to hit the **Fetch new scrape information** button to refresh.
+**ProTip:** To debug Open Graph data use [this tool](https://developers.facebook.com/tools/debug/) to test your pages. If content changes aren't reflected you will probably have to hit the **Scrape Again** button to refresh.
 {: .notice--info}
 
 ##### Open Graph default image

--- a/docs/_docs/05-configuration.md
+++ b/docs/_docs/05-configuration.md
@@ -710,7 +710,7 @@ Formerly known as [Google Webmaster Tools](https://www.google.com/webmasters/too
 
 #### Bing Webmaster Tools
 
-There are several ways to [verify site ownership](https://www.bing.com/webmaster/help/how-to-verify-ownership-of-your-site-afcfefc6) --- the easiest adding an authentication code to your config file.
+There are several ways to [verify site ownership](https://www.bing.com/webmasters/help/add-and-verify-site-12184f8b) --- the easiest adding an authentication code to your config file.
 
 Copy and paste the string inside of `content`:
 


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - Read the contributing document at https://github.com/mmistakes/minimal-mistakes#contributing
-->

<!--
  Choose one of the following by uncommenting it:
-->

<!-- This is a bug fix. -->
<!-- This is an enhancement or feature. -->
This is a documentation change.

## Summary

### Fix broken Bing Webmaster Tools Link

Link to Bing Webmaster Tools in the [configuration docs](https://mmistakes.github.io/minimal-mistakes/docs/configuration/#bing-webmaster-tools) was broken.

Previous link was [this](https://www.bing.com/webmaster/help/how-to-verify-ownership-of-your-site-afcfefc6), which leads to `page can’t be found` error. Updated to [this new link](https://www.bing.com/webmasters/help/add-and-verify-site-12184f8b) with this commit.

### Fix broken Open Graph debug tool link

Link to Open Graph debug tool in the [configuration docs](https://mmistakes.github.io/minimal-mistakes/docs/configuration/#facebook-open-graph) was broken.

Previous link was [this](https://developers.facebook.com/tools/debug/og/object?q=https%3A%2F%2Fmademistakes.com), which leads to `Page Not Found` error. Updated to [this new link](https://developers.facebook.com/tools/debug/) with this commit.

### Add Baidu site verification

There is a documentation of Baidu site verification but it wasn't present in `_config.yml` files. Added `baidu_site_verification` entry to both `_config.yml` and `docs/_config.yml`. Also re-ordered the SEO related configurations to match the order found in the [configurations docs](https://mmistakes.github.io/minimal-mistakes/docs/configuration/#seo-social-sharing-and-analytics-settings).

## Context

**Add Baidu site verification** is related to issue #2830.