### PR TITLE
Use <a> color for blockquote.notice border

### DIFF
--- a/_sass/minimal-mistakes/_notices.scss
+++ b/_sass/minimal-mistakes/_notices.scss
@@ -53,6 +53,10 @@
     }
   }
 
+  @at-root #{selector-unify(&, "blockquote")} {
+    border-left-color: mix(#000, $notice-color, 10%);
+  }
+
   code {
     background-color: mix($background-color, $notice-color, $code-notice-background-mix)
   }


### PR DESCRIPTION
This is an enhancement or feature.

## Summary

Uses the color of `.notice--whatever a` for `blockquote.notice--whatever # border-left-color`.

## Context

#3068 