### PR TITLE
feat: Sort comments by date ascending

### DIFF
--- a/_includes/comments.html
+++ b/_includes/comments.html
@@ -17,14 +17,23 @@
           <div class="js-comments">
             {% if site.data.comments[page.slug] %}
               <h4 class="page__comments-title">{{ site.data.ui-text[site.locale].comments_title | default: "Comments" }}</h4>
-              {% assign comments = site.data.comments[page.slug] | sort %}
+              {% assign comments = site.data.comments[page.slug] %}
+
+              <!-- In order to sort by date we must have an array of objects, not an array of arrays, so
+                    create a new array of plain comment objects and then sort by the comment date. -->
+              {% assign commentObjects = '' | split: '' %}
+              {% for comment in comments %}
+                {% assign commentObject = comment[1] %}
+                {% assign commentObjects = commentObjects | push: commentObject %}
+              {% endfor %}
+              {% assign comments = commentObjects | sort: "date" %}
 
               {% for comment in comments %}
-                {% assign email = comment[1].email %}
-                {% assign name = comment[1].name %}
-                {% assign url = comment[1].url %}
-                {% assign date = comment[1].date %}
-                {% assign message = comment[1].message %}
+                {% assign email = comment.email %}
+                {% assign name = comment.name %}
+                {% assign url = comment.url %}
+                {% assign date = comment.date %}
+                {% assign message = comment.message %}
                 {% include comment.html index=forloop.index email=email name=name url=url date=date message=message %}
               {% endfor %}
             {% endif %}
@@ -91,14 +100,23 @@
           <div class="js-comments">
             {% if site.data.comments[page.slug] %}
               <h4 class="page__comments-title">{{ site.data.ui-text[site.locale].comments_title | default: "Comments" }}</h4>
-              {% assign comments = site.data.comments[page.slug] | sort %}
+              {% assign comments = site.data.comments[page.slug] %}
+
+              <!-- In order to sort by date we must have an array of objects, not an array of arrays, so
+                    create a new array of plain comment objects and then sort by the comment date. -->
+              {% assign commentObjects = '' | split: '' %}
+              {% for comment in comments %}
+                {% assign commentObject = comment[1] %}
+                {% assign commentObjects = commentObjects | push: commentObject %}
+              {% endfor %}
+              {% assign comments = commentObjects | sort: "date" %}
 
               {% for comment in comments %}
-                {% assign email = comment[1].email %}
-                {% assign name = comment[1].name %}
-                {% assign url = comment[1].url %}
-                {% assign date = comment[1].date %}
-                {% assign message = comment[1].message %}
+                {% assign email = comment.email %}
+                {% assign name = comment.name %}
+                {% assign url = comment.url %}
+                {% assign date = comment.date %}
+                {% assign message = comment.message %}
                 {% include comment.html index=forloop.index email=email name=name url=url date=date message=message %}
               {% endfor %}
             {% endif %}


### PR DESCRIPTION
This is an enhancement or feature.

## Summary

Currently the order that comments appear on a post are random. This PR sorts the comments by date in ascending order, so oldest comments appear at the top, and newest comments down at the bottom.

### Unrelated

Also, would you consider adding the `hacktoberfest` label to your GitHub repository. This encourages more people to contribute to your repository, and allows PRs like this to count towards [hacktoberfest](https://hacktoberfest.digitalocean.com). Thanks!