### PR TITLE
Fix keybase class

### DIFF
--- a/_includes/author-profile.html
+++ b/_includes/author-profile.html
@@ -59,7 +59,7 @@
       {% if author.keybase %}
         <li>
           <a href="https://keybase.io/{{ author.keybase }}" itemprop="sameAs" rel="nofollow noopener noreferrer me">
-            <i class="fas fa-fw fa-key" aria-hidden="true"></i><span class="label">Keybase</span>
+            <i class="fas fa-fw fa-keybase" aria-hidden="true"></i><span class="label">Keybase</span>
           </a>
         </li>
       {% endif %}

--- a/_includes/author-profile.html
+++ b/_includes/author-profile.html
@@ -59,7 +59,7 @@
       {% if author.keybase %}
         <li>
           <a href="https://keybase.io/{{ author.keybase }}" itemprop="sameAs" rel="nofollow noopener noreferrer me">
-            <i class="fas fa-fw fa-keybase" aria-hidden="true"></i><span class="label">Keybase</span>
+            <i class="fab fa-fw fa-keybase" aria-hidden="true"></i><span class="label">Keybase</span>
           </a>
         </li>
       {% endif %}


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - Read the contributing document at https://github.com/mmistakes/minimal-mistakes#contributing
-->

<!--
  Choose one of the following by uncommenting it:
-->

This is a bug fix. 
<!-- This is an enhancement or feature. -->
<!-- This is a documentation change. -->

## Summary

Keybase icon was not showing. Looks like it has the wrong class. See https://fontawesome.com/v5.15/icons/keybase?style=brands