### PR TITLE
✏ fix typo

### DIFF
--- a/docs/_docs/05-configuration.md
+++ b/docs/_docs/05-configuration.md
@@ -813,7 +813,7 @@ facebook:
 
 ##### Open Graph default image
 
-For pages that don't have a `header.image` assigned in their YAML Front Matter, `site.og_image` will be used as a fallback. Use your logo, icon, avatar or something else that is meaningful. Just make sure it is place in the `/assets/images/` folder, a minimum size of 120px by 120px, and less than 1MB in file size.
+For pages that don't have a `header.image` assigned in their YAML Front Matter, `site.og_image` will be used as a fallback. Use your logo, icon, avatar or something else that is meaningful. Just make sure it is placed in the `/assets/images/` folder, has a minimum size of 120px by 120px, and is less than 1MB in file size.
 
 ```yaml
 og_image: /assets/images/site-logo.png


### PR DESCRIPTION
This is a documentation change.

## Summary

Spotted a small typo while I was reading about the `og_image` [setting](https://mmistakes.github.io/minimal-mistakes/docs/configuration/#open-graph-default-image).

## Context

Not related to an issue.