### PR TITLE
Fix inline code style not applied to stylized text

### DIFF
--- a/_sass/minimal-mistakes/_base.scss
+++ b/_sass/minimal-mistakes/_base.scss
@@ -160,24 +160,6 @@ pre {
   overflow-x: auto; /* add scrollbars to wide code blocks*/
 }
 
-p > code,
-a > code,
-li > code,
-figcaption > code,
-td > code {
-  padding-top: 0.1rem;
-  padding-bottom: 0.1rem;
-  font-size: 0.8em;
-  background: $code-background-color;
-  border-radius: $border-radius;
-
-  &:before,
-  &:after {
-    letter-spacing: -0.2em;
-    content: "\00a0"; /* non-breaking space*/
-  }
-}
-
 /* horizontal rule */
 
 hr {

--- a/_sass/minimal-mistakes/_page.scss
+++ b/_sass/minimal-mistakes/_page.scss
@@ -146,8 +146,8 @@ body {
     background: $code-background-color;
     border-radius: $border-radius;
 
-    &:before,
-    &:after {
+    &::before,
+    &::after {
       letter-spacing: -0.2em;
       content: "\00a0"; /* non-breaking space*/
     }

--- a/_sass/minimal-mistakes/_page.scss
+++ b/_sass/minimal-mistakes/_page.scss
@@ -139,6 +139,20 @@ body {
     }
   }
 
+  :not(pre) > code {
+    padding-top: 0.1rem;
+    padding-bottom: 0.1rem;
+    font-size: 0.8em;
+    background: $code-background-color;
+    border-radius: $border-radius;
+
+    &:before,
+    &:after {
+      letter-spacing: -0.2em;
+      content: "\00a0"; /* non-breaking space*/
+    }
+  }
+
   dt {
     margin-top: 1em;
     font-family: $sans-serif;


### PR DESCRIPTION
This is a bug fix.

"Inline code block" styles are currently not applied to `b > code`, `i > code`, `u > code` etc. due to selectors restricting parent elements to a very small set.

I checked the result of an "apparent fix" and only `pre > code` has a bad look, so I came up with `:not(pre) > code` inside `.page__content` and the result is satisfactory.

![issue](https://user-images.githubusercontent.com/7273074/143731928-99f6dc2a-1d56-46b9-8457-62bfbb329706.png)
