### PR TITLE
Automatically close invalid PRs using GitHub Actions

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -24,3 +24,8 @@
 <!--
   Is this related to any GitHub issue(s)?
 -->
+
+<!--
+  Please delete this comment if you confirm that you want to submit this Pull Request.
+  CHECK_PR_DID_NOT_CONFIRM
+-->

--- a/.github/workflows/bad-pr.yml
+++ b/.github/workflows/bad-pr.yml
@@ -9,6 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     if: "contains(github.event.pull_request.body, 'CHECK_PR_DID_NOT_CONFIRM') || github.event.pull_request.body == ''"
     steps:
+      - uses: actions-ecosystem/action-add-labels@v1
+        with:
+          labels: 'Type: Invalid'
       - uses: superbrothers/close-pull-request@v3
         with:
           # Optional. Post an issue comment just before closing a pull request.

--- a/.github/workflows/bad-pr.yml
+++ b/.github/workflows/bad-pr.yml
@@ -1,0 +1,15 @@
+name: Cleanup bad PR
+
+on:
+  pull_request_target:
+    types: [opened, reopened]
+
+jobs:
+  close-pr:
+    runs-on: ubuntu-latest
+    if: "contains(github.event.pull_request.body, 'CHECK_PR_DID_NOT_CONFIRM')"
+    steps:
+      - uses: superbrothers/close-pull-request@v3
+        with:
+          # Optional. Post an issue comment just before closing a pull request.
+          comment: "This PR is not valid for inclusion. Please check again if you're submitting improvements for *the theme*."

--- a/.github/workflows/bad-pr.yml
+++ b/.github/workflows/bad-pr.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   close-pr:
     runs-on: ubuntu-latest
-    if: "contains(github.event.pull_request.body, 'CHECK_PR_DID_NOT_CONFIRM')"
+    if: "contains(github.event.pull_request.body, 'CHECK_PR_DID_NOT_CONFIRM') || github.event.pull_request.body == ''"
     steps:
       - uses: superbrothers/close-pull-request@v3
         with:


### PR DESCRIPTION
This is an enhancement or feature.

## Summary

Use a GitHub Actions to close invalid PRs that would have been done manually.

This PR adds two aspects of content:

1. An "identification token" for detection, based on the fact that most (if not all) invalid PRs don't even bother reading the `PULL_REQUEST_TEMPLATE`, let alone properly filling them. This provides us with a nice simple heuristic that should "just work" for 99% of the cases.

    This PR adds something at the end of the PR template with the hope that a reasonable user would have removed it should they want to submit some real thing, and checks if the "must remove" content is left intact.

    **Update 1**: Shortly after the creation of this PR there came 3314 that included an empty body (the user just deleted everything pre-filled in the input box). Considering that this could also be a pattern, I updated the workflow file to include a check for this case.

2. A workflow file that runs on every opened or reopened PR, checking the "identification token", and closes it if found.

    This workflow runs on [`pull_request_target`][5] because [the intuitive `pull_request` event does *not* trigger a workflow run if the PR has merge conflicts][1], which is often the case for invalid PRs. There's a reply suggesting this alternative trigger that according to my tests, works.

Unfortunately, I have yet to discover an easy way to perform these actions (comment + close) using only GitHub-provided workflow steps. While I certainly could craft API calls using `curl` or another command-line tool (or use more sophisticated things like Python, altogether), I chose not to overcomplicate things and use a Marketplace Actions step. If external dependencies are a concern to you, I'm happy to do this myself with scripts. Please let me know if this is the case.

Since we're not loading any content from the submitted PR (ot any code at all), we should be safe from (malicious) code. The only input we're consuming is a string sent as part of the event payload. The only operation performed on it is [`contains()`][6] which is a substring match. TBH I would have been shocked if there *were* any security concerns on this simple thing.

### Demo

Please see [this PR][3] and [this workflow run][4] on my repo.

## Context

Recent influx of invalid PRs that submit personal site content instead of something intended to be included into the project.

P.S. I've been watching this repository for years and I too am tired of unsubscribing every invalid PR and cleaning up my email inbox.

  [1]: https://github.community/t/run-actions-on-pull-requests-with-merge-conflicts/17104
  [2]: https://github.community/t/run-actions-on-pull-requests-with-merge-conflicts/17104/16
  [3]: https://github.com/iBug/minimal-mistakes/pull/3
  [4]: https://github.com/iBug/minimal-mistakes/runs/4649236398
  [5]: https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#pull_request_target
  [6]: https://docs.github.com/en/actions/learn-github-actions/expressions#contains