### PR TITLE
fix typo about loading javascript in footer

### DIFF
--- a/docs/_docs/10-layouts.md
+++ b/docs/_docs/10-layouts.md
@@ -837,10 +837,10 @@ Add some Liquid tags for the new configuration to `_includes/footer/custom.html`
 {% endif %}
 ```{% endraw %}
 
-Next, add `page_js` to any page's YAML Front Matter to have your CSS loaded for that page.
+Next, add `page_js` to any page's YAML Front Matter to have your JavaScript loaded for that page.
 ```yaml
 page_js:
-  - /path/to/your/custom.css
+  - /path/to/your/custom.js
 ```
 
 ---


### PR DESCRIPTION
 This is a documentation change. 

## Summary

I found a typo, likely due to a copy/paste duplication

## Context

Not related to an issue