### PR TITLE
add optional lunr searching of pages

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -62,6 +62,8 @@ atom_feed:
 search                   : # true, false (default)
 search_full_content      : # true, false (default)
 search_provider          : # lunr (default), algolia, google
+lunr:
+  search_within_pages    : # true, false (default)
 algolia:
   application_id         : # YOUR_APPLICATION_ID
   index_name             : # YOUR_INDEX_NAME

--- a/assets/js/lunr/lunr-store.js
+++ b/assets/js/lunr/lunr-store.js
@@ -46,4 +46,38 @@ var store = [
         "teaser": {{ teaser | relative_url | jsonify }}
       }{%- unless forloop.last and l -%},{%- endunless -%}
     {%- endfor -%}
-  {%- endfor -%}]
+  {%- endfor -%}{%- if site.lunr.search_within_pages -%},
+  {%- for doc in site.pages -%}
+    {%- if forloop.last -%}
+      {%- assign l = true -%}
+    {%- endif -%}
+  {
+    "title": {{ doc.title | jsonify }},
+    "excerpt":
+        {%- if site.search_full_content == true -%}
+          {{ doc.content | newline_to_br |
+            replace:"<br />", " " |
+            replace:"</p>", " " |
+            replace:"</h1>", " " |
+            replace:"</h2>", " " |
+            replace:"</h3>", " " |
+            replace:"</h4>", " " |
+            replace:"</h5>", " " |
+            replace:"</h6>", " "|
+          strip_html | strip_newlines | jsonify }},
+        {%- else -%}
+          {{ doc.content | newline_to_br |
+            replace:"<br />", " " |
+            replace:"</p>", " " |
+            replace:"</h1>", " " |
+            replace:"</h2>", " " |
+            replace:"</h3>", " " |
+            replace:"</h4>", " " |
+            replace:"</h5>", " " |
+            replace:"</h6>", " "|
+          strip_html | strip_newlines | truncatewords: 50 | jsonify }},
+        {%- endif -%}
+      "url": {{ doc.url | absolute_url | jsonify }}
+  }{%- unless forloop.last and l -%},{%- endunless -%}
+  {%- endfor -%}
+{%- endif -%}]

--- a/docs/_docs/05-configuration.md
+++ b/docs/_docs/05-configuration.md
@@ -618,6 +618,13 @@ To enable site-wide search add `search: true` to your `_config.yml`.
 
 The default search uses [**Lunr**](https://lunrjs.com/) to build a search index of all post and your documents in collections. This method is 100% compatible with sites hosted on GitHub Pages.
 
+To have it index all pages, update `lunr` in `_config.yml` like so:
+
+```yaml
+lunr:
+  search_within_pages: true
+```
+
 **Note:** Only the first 50 words of a post or page's body content is added to the Lunr search index. Setting `search_full_content` to `true` in your `_config.yml` will override this and could impact page load performance.
 {: .notice--warning}
 


### PR DESCRIPTION
This is an enhancement or feature. 
This is a documentation change. 

## Summary

This gives an optional setting to allow lunr to search all pages and not just the ones in the collections.
I also updated the docs to describe how to use it. 

I needed this for my own website and figure I'd port the changes over for everyone since it's extremely useful to have when you need it.

I used a modified version of the suggested changes by @nandahkrishna  https://github.com/mmistakes/minimal-mistakes/issues/1409#issuecomment-569402881 (note: their repo is MIT license)

## Context

This addresses #1409
