### PR TITLE
Update attribution link

### DIFF
--- a/assets/js/plugins/jquery.greedy-navigation.js
+++ b/assets/js/plugins/jquery.greedy-navigation.js
@@ -1,7 +1,7 @@
 /*
-GreedyNav.js - http://lukejacksonn.com/actuate
+GreedyNav.js - https://github.com/lukejacksonn/GreedyNav
 Licensed under the MIT license - http://opensource.org/licenses/MIT
-Copyright (c) 2015 Luke Jackson
+Copyright (c) 2015 Luke Jackson http://lukejacksonn.com
 */
 
 $(function() {


### PR DESCRIPTION

This is a documentation change.

## Summary
Update attribution link for GreedyNav

## Context


https://github.com/mmistakes/minimal-mistakes/issues/3552

