### PR TITLE
WIP: Og image alt

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -85,6 +85,7 @@ facebook:
   app_id                 :
   publisher              :
 og_image                 : # Open Graph/Twitter default site image
+og_image_alt             : # Alternative text for Open Graph/Twitter image for screen readers
 # For specifying social profiles
 # - https://developers.google.com/structured-data/customize/social-profiles
 social:

--- a/_includes/seo.html
+++ b/_includes/seo.html
@@ -41,6 +41,9 @@
 {%- assign site_og_image = site.og_image | absolute_url -%}
 {%- assign site_og_image = site_og_image | escape -%}
 
+{%- assign site_og_image_alt = site.og_image_alt -%}
+{%- assign site_og_image_alt = site_og_image_alt | escape -%}
+
 {%- if page.date -%}
   {%- assign og_type = "article" -%}
 {%- else -%}
@@ -71,6 +74,7 @@
   <meta property="og:image" content="{{ page_large_image }}">
 {% elsif page_teaser_image %}
   <meta property="og:image" content="{{ page_teaser_image }}">
+  <meta property="og:image:alt" content="{{ site_og_image_alt }}">
 {% endif %}
 
 {% if site.twitter.username %}
@@ -86,6 +90,7 @@
     <meta name="twitter:card" content="summary">
     {% if page_teaser_image %}
       <meta name="twitter:image" content="{{ page_teaser_image }}">
+      <meta property="twitter:image:alt" content="{{ site_og_image_alt }}">
     {% endif %}
   {% endif %}
 

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -78,6 +78,7 @@ facebook:
   app_id                 :
   publisher              :
 og_image                 : "/assets/images/site-logo.png" # Open Graph/Twitter default site image
+og_image_alt             : "Minimal mistakes logo" # Alternative text for screen readers
 # For specifying social profiles, used in _includes/seo.html
 # - https://developers.google.com/structured-data/customize/social-profiles
 social:


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - Read the contributing document at https://github.com/mmistakes/minimal-mistakes#contributing
-->

<!--
  Choose one of the following by uncommenting it:
-->

This is a bug fix.
This is an enhancement or feature.
<!-- This is a documentation change. -->

## Summary
Adding alt text for open graph images

## Context
https://github.com/mmistakes/minimal-mistakes/issues/3562

## Further information
Changes are still needed to fit the current logic in https://github.com/mmistakes/minimal-mistakes/blob/master/_includes/seo.html These are
- [ ] add alt text for page_large_image
  - [ ] add alt text for page.header.og_image 
  - [ ] add alt text for page.header.overlay_image 
  - [ ] add alt text for page.header.image

- [ ] add alt text for page_teaser_image
  - [X] add alt text for site_og_image
  - [ ] add alt text for page.header.teaser
  