### PR TITLE
Update link to Font Awesome gallery

### DIFF
--- a/docs/_docs/05-configuration.md
+++ b/docs/_docs/05-configuration.md
@@ -900,7 +900,7 @@ Author links are all optional, include the ones you want visible under the `auth
 | Name | Description |
 | --- | --- |
 | **label** | Link label (e.g. `"Twitter"`) |
-| **icon** | [Font Awesome icon](https://fontawesome.com/icons?d=gallery) classes (e.g. `"fab fa-fw fa-twitter-square"`) |
+| **icon** | [Font Awesome icon](https://fontawesome.com/v5/search) classes (e.g. `"fab fa-fw fa-twitter-square"`) |
 | **url** | Link URL (e.g. `"https://twitter.com/mmistakes"`) |
 
 ```yaml
@@ -933,7 +933,7 @@ Footer links can be added under the `footer.links` array.
 | Name | Description |
 | --- | --- |
 | **label** | Link label (e.g. `"Twitter"`) |
-| **icon** | [Font Awesome icon](https://fontawesome.com/icons?d=gallery) classes (e.g. `"fab fa-fw fa-twitter-square"`) |
+| **icon** | [Font Awesome icon](https://fontawesome.com/v5/search) classes (e.g. `"fab fa-fw fa-twitter-square"`) |
 | **url** | Link URL (e.g. `"https://twitter.com/mmistakes"`) |
 
 ```yaml

--- a/docs/_docs/10-layouts.md
+++ b/docs/_docs/10-layouts.md
@@ -128,7 +128,7 @@ Auto-generated table of contents list for your posts and pages can be enabled by
 | ---------   | -------- | ----------- | ------- |
 | **toc**     | Optional | Show table of contents. (boolean) | `false` |
 | **toc_label** | Optional | Table of contents title. (string) | `toc_label` in UI Text data file. |
-| **toc_icon**  | Optional | Table of contents icon, displays before the title. (string) | [Font Awesome](https://fontawesome.com/icons?d=gallery&s=solid&m=free) <i class="fas fa-file-alt"></i> **file-alt** icon. Other FA icons can be used instead. |
+| **toc_icon**  | Optional | Table of contents icon, displays before the title. (string) | [Font Awesome](https://fontawesome.com/v5/search?s=solid&m=free) <i class="fas fa-file-alt"></i> **file-alt** icon. Other FA icons can be used instead. |
 | **toc_sticky** | Optional | Stick table of contents to top of screen.                   | `false` |
 
 **TOC example with custom title and icon**
@@ -593,7 +593,7 @@ defaults:
 **Note:** To disable the author sidebar profile for a specific post or page, add `author_profile: false` to the YAML Front Matter instead.
 {: .notice--warning}
 
-To assign more author links, add to the `author.links` array  in [`_config.yml`]({{ "/docs/configuration/" | relative_url }}) link so. Any of [Font Awesome's icons](https://fontawesome.com/icons?d=gallery) are available for use.
+To assign more author links, add to the `author.links` array  in [`_config.yml`]({{ "/docs/configuration/" | relative_url }}) link so. Any of [Font Awesome's icons](https://fontawesome.com/v5/search) are available for use.
 
 ```yaml
 author:

--- a/docs/_docs/14-helpers.md
+++ b/docs/_docs/14-helpers.md
@@ -279,7 +279,7 @@ Add `toc: true` to the YAML Front Matter of any post or page.
 | -------------- | -------- | ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **toc**        | Optional | Show table of contents. (boolean)                           | `false`                                                                                                                                                       |
 | **toc_label**  | Optional | Table of contents title. (string)                           | `toc_label` in UI Text data file.                                                                                                                             |
-| **toc_icon**   | Optional | Table of contents icon, displays before the title. (string) | [Font Awesome](https://fontawesome.com/icons?d=gallery&s=solid&m=free) <i class="fas fa-file-alt"></i> **file-alt** icon. Other FA icons can be used instead. |
+| **toc_icon**   | Optional | Table of contents icon, displays before the title. (string) | [Font Awesome](https://fontawesome.com/v5/search?s=solid&m=free) <i class="fas fa-file-alt"></i> **file-alt** icon. Other FA icons can be used instead. |
 | **toc_sticky** | Optional | Stick table of contents to top of screen.                   | `false`                                                                                                                                                       |
 
 **TOC example with custom title and icon**
@@ -337,7 +337,7 @@ To include a Kramdown [auto-generated table of contents](https://kramdown.gettal
 | Parameter | Required | Description                                                 | Default                                                                                                                                                       |
 | --------- | -------- | ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **title** | Optional | Table of contents title. (string)                           | `toc_label` in UI Text data file.                                                                                                                             |
-| **icon**  | Optional | Table of contents icon, displays before the title. (string) | [Font Awesome](https://fontawesome.com/icons?d=gallery&s=solid&m=free) <i class="fas fa-file-alt"></i> **file-alt** icon. Other FA icons can be used instead. |
+| **icon**  | Optional | Table of contents icon, displays before the title. (string) | [Font Awesome](https://fontawesome.com/v5/search?s=solid&m=free) <i class="fas fa-file-alt"></i> **file-alt** icon. Other FA icons can be used instead. |
 
 **TOC example with custom title and icon**
 


### PR DESCRIPTION
This is a documentation change.

## Summary

Font Awesome has since released v6 and the old `/icons?d=gallery` path has been changed to `/v5/search`. This PR updates such links in the documentation site.

## P.S.

Any plans for the next release? PRs are piling up.