### PR TITLE
Improve image quality when downscaling

### DIFF
--- a/_sass/minimal-mistakes/_reset.scss
+++ b/_sass/minimal-mistakes/_reset.scss
@@ -120,6 +120,7 @@ img {
   vertical-align: middle;
   border: 0;
   -ms-interpolation-mode: bicubic;
+  image-rendering: -webkit-optimize-contrast;
 }
 
 /* Prevent max-width from affecting Google Maps */


### PR DESCRIPTION
This is an enhancement.

## Summary

There's an issue with this theme, at least on Chrome. When the browser has to downscale an image, the quality is bad - the downscaled image is blurry.

This is a quick fix that dramatically improves the quality of downscaled images, at least on Chrome. I can also test it on other browsers if that's necessary.

## Test results

Note: you may need to download these images or open them in a separate tab to see the difference clearly.

### Your average GUI, downscaled

#### Before

![MenuBefore](https://user-images.githubusercontent.com/42816979/167942520-daf68646-15d5-40b3-9866-da73052af752.png)

#### After

![MenuAfter](https://user-images.githubusercontent.com/42816979/167942572-e10f5889-744c-491f-b325-6efefad3d84b.png)

### Your average anime picture [(source)](https://www.pixiv.net/en/artworks/97939477), downscaled

#### Before

![AnimeBefore](https://user-images.githubusercontent.com/42816979/167942746-5b49e974-47f9-47d1-a84d-d9a56b8774cb.png)

#### After

![AnimeAfter](https://user-images.githubusercontent.com/42816979/167942994-27227653-42cb-4f74-ba03-3e2c91b58655.png)