### PR TITLE
Remove IE9 upgrade notice

### DIFF
--- a/_includes/browser-upgrade.html
+++ b/_includes/browser-upgrade.html
@@ -1,3 +1,0 @@
-<!--[if lt IE 9]>
-<div class="notice--danger align-center" style="margin: 0;">You are using an <strong>outdated</strong> browser. Please <a href="https://browsehappy.com/">upgrade your browser</a> to improve your experience.</div>
-<![endif]-->

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -16,7 +16,6 @@
 
   <body class="layout--{{ page.layout | default: layout.layout }}{% if page.classes or layout.classes %}{{ page.classes | default: layout.classes | join: ' ' | prepend: ' ' }}{% endif %}">
     {% include_cached skip-links.html %}
-    {% include_cached browser-upgrade.html %}
     {% include_cached masthead.html %}
 
     <div class="initial-content">


### PR DESCRIPTION
This is an enhancement or feature.

## Summary

Since #3042 has been merged, the notice block is also only bloated bytes now.
