### PR TITLE
Fix #3096 enabling breadcrumb on all pages

### DIFF
--- a/_layouts/single.html
+++ b/_layouts/single.html
@@ -8,7 +8,7 @@ layout: default
   {% include page__hero_video.html %}
 {% endif %}
 
-{% if page.url != "/" and site.breadcrumbs or page.breadcrumbs != false %}
+{% if page.url != "/" and site.breadcrumbs or page.breadcrumbs %}
   {% unless paginator %}
     {% include breadcrumbs.html %}
   {% endunless %}


### PR DESCRIPTION
This is a bug fix.

## Summary

See commit info.

According to [Liquid docs](https://shopify.github.io/liquid/basics/operators/#order-of-operations), operators are grouped from right to left, so the existing code is evaluated like this:

```ruby
if page.url != "/" and site.breadcrumbs or page.breadcrumbs != false
if page.url != "/" and (site.breadcrumbs or page.breadcrumbs != false)
```

With `page.breadcrumbs` unset, it becomes `null`, so the last part evaluates to `true` for all pages (for an average user), thus unintendedly enabling breadcrumbs.

## Context

[Someone commented](https://github.com/mmistakes/minimal-mistakes/commit/65237df377bf224fdfe3ebac05105e14791e49f8#commitcomment-74852556)