### PR TITLE
Fix #3668 breaking "disable per-page when globally enabled"

### DIFF
--- a/_layouts/single.html
+++ b/_layouts/single.html
@@ -8,7 +8,8 @@ layout: default
   {% include page__hero_video.html %}
 {% endif %}
 
-{% if page.url != "/" and site.breadcrumbs or page.breadcrumbs %}
+{% assign breadcrumb_enabled = page.breadcrumbs | default: site.breadcrumbs %}
+{% if page.url != "/" and breadcrumb_enabled %}
   {% unless paginator %}
     {% include breadcrumbs.html %}
   {% endunless %}

--- a/_layouts/single.html
+++ b/_layouts/single.html
@@ -8,8 +8,11 @@ layout: default
   {% include page__hero_video.html %}
 {% endif %}
 
-{% assign breadcrumb_enabled = page.breadcrumbs | default: site.breadcrumbs %}
-{% if page.url != "/" and breadcrumb_enabled %}
+{% assign breadcrumbs_enabled = site.breadcrumbs %}
+{% if page.breadcrumbs != null %}
+  {% assign breadcrumbs_enabled = page.breadcrumbs %}
+{% endif %}
+{% if page.url != "/" and breadcrumbs_enabled %}
   {% unless paginator %}
     {% include breadcrumbs.html %}
   {% endunless %}


### PR DESCRIPTION
This is a bug fix.

## Summary

#3668 broke the original intent of "allow disabling breadcrumbs on a per-page basis when it's globally enabled (site-enabled)". I didn't realize that `!= false` held this intention.

Unfortunately [the `default` filter](https://shopify.github.io/liquid/filters/default/) doesn't fit this purpose (it eats `null`, `false` and empty strings) so I had to use another conditional. This should make both #3096 and the comment happy.