### PR TITLE
Improve PR close auto-comment message

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -26,6 +26,5 @@
 -->
 
 <!--
-  Please delete this comment if you confirm that you want to submit this Pull Request.
-  CHECK_PR_DID_NOT_CONFIRM
+  Please confirm that you want to submit this Pull Request to Minimal Mistakes, the free Jekyll theme by Michael Rose, by deleting this comment block.
 -->

--- a/.github/workflows/bad-pr.yml
+++ b/.github/workflows/bad-pr.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   close-pr:
     runs-on: ubuntu-latest
-    if: "contains(github.event.pull_request.body, 'CHECK_PR_DID_NOT_CONFIRM') || github.event.pull_request.body == ''"
+    if: "contains(github.event.pull_request.body, 'by deleting this comment block') || github.event.pull_request.body == ''"
     steps:
       - uses: actions-ecosystem/action-add-labels@v1
         with:
@@ -15,4 +15,8 @@ jobs:
       - uses: superbrothers/close-pull-request@v3
         with:
           # Optional. Post an issue comment just before closing a pull request.
-          comment: "This PR is not valid for inclusion. Please check again if you're submitting improvements for *the theme*."
+          comment: |
+            **You have created a Pull Request to the wrong repository.** This is the repository for [Minimal Mistakes][1], the free Jekyll theme. See [GitHub Docs: About pull requests][2] if you need help.
+
+              [1]: https://mmistakes.github.io/minimal-mistakes/
+              [2]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests

--- a/.github/workflows/bad-pr.yml
+++ b/.github/workflows/bad-pr.yml
@@ -20,3 +20,8 @@ jobs:
 
               [1]: https://mmistakes.github.io/minimal-mistakes/
               [2]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests
+      - uses: sudo-bot/action-pull-request-lock@v1.0.5
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          number: ${{ github.event.pull_request.number }}
+          lock-reason: spam


### PR DESCRIPTION
This is a follow-up for #3313. Apparently there are worse users who simply get confused as their PRs are closed. Improves the auto-comment to be absolutely clear they're in the wrong place.

Also changed the "detection token" to be part of the comment (that hopefully won't come up in a legitimate PR).