### PR TITLE
⬆️ load latest fontawesome package

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -15,8 +15,8 @@
 
 <!-- For all browsers -->
 <link rel="stylesheet" href="{{ '/assets/css/main.css' | relative_url }}">
-<link rel="preload" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@5/css/all.min.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
-<noscript><link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@5/css/all.min.css"></noscript>
+<link rel="preload" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@latest/css/all.min.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
+<noscript><link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@latest/css/all.min.css"></noscript>
 
 {% if site.head_scripts %}
   {% for script in site.head_scripts %}


### PR DESCRIPTION
This is an enhancement or feature.

## Summary
<!--
  Provide a description of what your pull request changes.
-->
Upgrade to the newest `fontawesome` package.
Until now the package has been fixed at version `5.0.0` and has thus never received any bugfixes.
By changing the `@5` to `@latest` in the version tag, minimal-mistakes now ships always with the newest up-to-date version.
(Currently, `6.1.1` is the newest)

## Context
<!--
  Is this related to any GitHub issue(s)?
-->
I am a researcher and therefore active on many research-related social platforms. I needed some icons that were introduced in later `patch-versions` of fontawesome version `5`, so I had to manually overwrite the `head.html` just to get the newest version. I believe that minimal-mistakes should always ship with the newest patch-version, as `5.0.0` is very outdated and does not include any patches that came after.
I am aware that minimal-mistakes should be kept minimal (and therefore not all requests can be met that only target specific individuals), but I assume that this patch should come in handy for a large-user base as there is no reason to limit ourselves to an old version if we can dynamically load always the latest release with `@latest`.