### PR TITLE
Fix wrong `first_page_path` because of hard-coded `page:num`

### DIFF
--- a/_includes/paginator.html
+++ b/_includes/paginator.html
@@ -1,6 +1,7 @@
 {% if paginator.total_pages > 1 %}
 <nav class="pagination">
-  {% assign first_page_path = paginator.first_page_path | default: site.paginate_path | replace: 'page:num', '' | replace: '//', '/' | relative_url %}
+  {% assign paginate_path_last = site.paginate_path | split: '/' | last %}
+  {% assign first_page_path = paginator.first_page_path | default: site.paginate_path | replace: paginate_path_last, '' | replace: '//', '/' | relative_url %}
   <ul>
     {% comment %} Link for previous page {% endcomment %}
     {% if paginator.previous_page %}


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - Read the contributing document at https://github.com/mmistakes/minimal-mistakes#contributing
-->

<!--
  Choose one of the following by uncommenting it:
-->

This is a bug fix.
<!-- This is an enhancement or feature. -->
<!-- This is a documentation change. -->

## Summary

<!--
  Provide a description of what your pull request changes.
-->
In code `assign first_page_path = ... | replace: 'page:num', '' | ...`, `page:num` is hard-coded. So if `site.paginate_path` doesn't ends with `page:num/` or `page:num`, `first_page_path` will get a wrong value.

The PR tries parsing the last part from `site.paginate_path`, instead of using a hard-coded `page:num`.

## Context

The same issue with: https://github.com/mmistakes/minimal-mistakes/pull/2431#issuecomment-598026992

> If `:num` is used alone (instead of `page:num`) then the previous code would generate wrong results. I have `paginate_path: /blog/:num/` in my config and I expect pages to have URLs like `/blog/2/` instead of `/blog/page2/`, which wasn't available before.

The author of  #2413 addressed the issue with Paginate V2. But I'm using GitHub Actions and only V1 is supported so I have to make the fix.


<br>

BTW, I'm new to Liquid and `"/blog/:num/" | split: "/"` returns `["", "blog", ":num"]`, instead of `["", "blog", ":num", ""]` as I expected. Weird... https://github.com/Shopify/liquid/issues/862
