### PR TITLE
Fix SVG logos not displayed without width/height attribute

### DIFF
--- a/_sass/minimal-mistakes/_masthead.scss
+++ b/_sass/minimal-mistakes/_masthead.scss
@@ -40,7 +40,7 @@
 }
 
 .site-logo img {
-  max-height: 2rem;
+  height: 2rem;
 }
 
 .site-title {


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - Read the contributing document at https://github.com/mmistakes/minimal-mistakes#contributing
-->

<!--
  Choose one of the following by uncommenting it:
-->

This is a bug fix.
<!-- This is an enhancement or feature. -->
<!-- This is a documentation change. -->

## Summary

<!--
  Provide a description of what your pull request changes.
-->

In the masthead styles I changed the `max-height` of the site logo to `height ` to allow for displaying SVG logos that don't have explicit width or height attributes set, which were previously rendered with 0 height, making them invisible.

## How This Change Will Affect Other Users

I have tried with multiple different combinations of logos and SVG attributes. This change won't affect the majority of users.
However, users who have a smaller logo which wasn't bound by the max-width of 2rem will now have a slightly bigger logo (2rem height), and of course the bug fix will affect users who were affected by the bug.

## Context

<!--
  Is this related to any GitHub issue(s)?
-->

This PR is related to the issue #3845 I opened.

