### PR TITLE
Remove overlay and revert X to hamburger icon when popup disappears

### DIFF
--- a/assets/js/plugins/jquery.greedy-navigation.js
+++ b/assets/js/plugins/jquery.greedy-navigation.js
@@ -107,6 +107,7 @@ $(function() {
     // Mouse has left, start the timer
     timer = setTimeout(function() {
       $hlinks.addClass('hidden');
+      $('.greedy-nav__toggle').removeClass('close');
     }, closingTime);
   }).on('mouseenter', function() {
     // Mouse is back, cancel the timer


### PR DESCRIPTION
This is a bug fix.

## Summary

![image](https://user-images.githubusercontent.com/78736225/196750367-5fea71fb-8755-4109-9564-29d07f07aa5a.png)

The pop up menu above disappears after you move the cursor out of it. However, the white overlay on the screen does not disappear, as well as the x nav button on the top-right, remains as is.

Now when you click anywhere on the screen, the popup appears again, and the x nav button turns back to a hamburger menu button.
And when you click on the hamburger menu, the popup disappears.

The functionality is now behaving in the exact opposite that we want to.

To remedy this, once the popup disappears the x nav button should also return back to normal (hamburger button)

This commit fixes this issue.

## Context

This is a direct pull request. No related Github issue