### PR TITLE
Remove JS and other files from search index

### DIFF
--- a/assets/js/lunr/lunr-store.js
+++ b/assets/js/lunr/lunr-store.js
@@ -47,7 +47,7 @@ var store = [
       }{%- unless forloop.last and l -%},{%- endunless -%}
     {%- endfor -%}
   {%- endfor -%}{%- if site.lunr.search_within_pages -%},
-  {%- assign pages = site.pages | where_exp:'doc','doc.search != false' -%}
+  {%- assign pages = site.pages | where_exp:'doc','doc.search != false and doc.title != null' -%}
   {%- for doc in pages -%}
     {%- if forloop.last -%}
       {%- assign l = true -%}


### PR DESCRIPTION
To avoid getting JS and irrelevant files indexed remove pages where title is null. This gives a much cleaner lunr store with more relevant content.