### PR TITLE
Add Docker Support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM jekyll/jekyll
+Label MAINTAINER Amir Pourmand
+#install imagemagick tool for convert command
+RUN apk add --no-cache --virtual .build-deps \
+        libxml2-dev \
+        shadow \
+        autoconf \
+        g++ \
+        make 
+WORKDIR /srv/jekyll
+ADD Gemfile /srv/jekyll/
+RUN bundle install

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,5 @@ RUN apk add --no-cache --virtual .build-deps \
         make 
 WORKDIR /srv/jekyll
 ADD Gemfile /srv/jekyll/
+ADD minimal-mistakes-jekyll.gemspec /srv/jekyll/
 RUN bundle install

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: "3"
+
+services:
+  jekyll_custom:
+    build: .
+    command: bash -c "
+      rm -f Gemfile.lock
+      && bundler exec jekyll serve --watch --port=8080 --host=0.0.0.0 --livereload --verbose --trace"
+    ports:
+      - 8080:8080
+    volumes:
+      - .:/srv/jekyll


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - Read the contributing document at https://github.com/mmistakes/minimal-mistakes#contributing
-->

<!--
  Choose one of the following by uncommenting it:
-->

<!-- This is a bug fix. -->
This is an enhancement or feature. 
<!-- This is a documentation change. -->

## Summary
I've added docker support.


<!--
  Provide a description of what your pull request changes.
-->

## Context

With this commit, you no longer have to install ruby and run `bundle install` and install all dependencies if you want to run the image locally. You can just install docker and run:

```
docker-compose up
```
It will automatically download jekyll image and then install all required dependencies in an isolated environment and run the website from there.

I've already tested this and it is working as expected.

