### PR TITLE
Link target can be specified

### DIFF
--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -14,7 +14,7 @@
         <ul class="visible-links">
           {%- for link in site.data.navigation.main -%}
             <li class="masthead__menu-item">
-              <a href="{{ link.url | relative_url }}"{% if link.description %} title="{{ link.description }}"{% endif %}>{{ link.title }}</a>
+              <a href="{{ link.url | relative_url }}"{% if link.description %} title="{{ link.description }}"{% endif %} {% if link.target %} target="{{ link.target }}" {% endif %}>{{ link.title }}</a>
             </li>
           {%- endfor -%}
         </ul>


### PR DESCRIPTION
This is an enhancement or feature. 

## Summary

Use this when you want to display the contents in a new window when you click the header link.
Setting 'link.target' allows you to specify the target of the anchor tag to display the content as the desired target.
For example, you can set navigation.yml as follows.

```yaml
main:
  - title: "Posts"
    url: /posts/
  - title: "Categories"
    url: /categories/
  - title: "Tags"
    url: /tags/
  - title: "/somewhere/"
    url: https://somewhere
    target: "_blank" # new window
```
