### PR TITLE
Add rel="me" to footer links for web sign-in

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -7,7 +7,7 @@
     {% if site.footer.links %}
       {% for link in site.footer.links %}
         {% if link.label and link.url %}
-          <li><a href="{{ link.url }}" rel="nofollow noopener noreferrer"><i class="{{ link.icon | default: 'fas fa-link' }}" aria-hidden="true"></i> {{ link.label }}</a></li>
+          <li><a href="{{ link.url }}" rel="nofollow noopener noreferrer me"><i class="{{ link.icon | default: 'fas fa-link' }}" aria-hidden="true"></i> {{ link.label }}</a></li>
         {% endif %}
       {% endfor %}
     {% endif %}


### PR DESCRIPTION
✨ This is an enhancement or feature that builds on the microformat contributions by @dltj in https://github.com/mmistakes/minimal-mistakes/pull/3052.

Adding `rel="me"` to footer links [enables web sign-in](https://indieweb.org/How_to_set_up_web_sign-in_on_your_own_domain) or [RelMeAuth](https://microformats.org/wiki/RelMeAuth), so you can use your domain to sign in to other sites.

In https://github.com/mmistakes/minimal-mistakes/pull/3052, the `rel="me"` attributes were added to the _author profile_, but that only appears in post sidebars, and web sign-in requires these profile links to be present on the home page.

Adding this to the footer links ensures that these values are correctly detected by systems that check for the presence of bidirectional links between the author's home page and other profiles.

✅ Tested with the [Web Sign In](https://indiewebify.me/validate-rel-me/) test at https://indiewebify.me.