### PR TITLE
Google analytics V4

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -96,7 +96,7 @@ social:
 
 # Analytics
 analytics:
-  provider               : false # false (default), "google", "google-universal", "google-gtag", "custom"
+  provider               : false # false (default), "google", "google-universal", "google-gtag", "google-v4", "custom"
   google:
     tracking_id          :
     anonymize_ip         : # true, false (default)

--- a/_includes/analytics-providers/google-v4.html
+++ b/_includes/analytics-providers/google-v4.html
@@ -1,0 +1,10 @@
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id={{ site.analytics.google.tracking_id }}"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', '{{ site.analytics.google.tracking_id }}');
+</script>
+

--- a/_includes/analytics.html
+++ b/_includes/analytics.html
@@ -7,6 +7,8 @@
   {% include /analytics-providers/google-universal.html %}
 {% when "google-gtag" %}
   {% include /analytics-providers/google-gtag.html %}
+{% when "google-v4" %}
+  {% include /analytics-providers/google-v4.html %}
 {% when "custom" %}
   {% include /analytics-providers/custom.html %}
 {% endcase %}


### PR DESCRIPTION
This is an enhancement or feature.

## Summary
Google is deprecating google-universal in July.  They are encouraging to swap to V4, which includes a new tag.