### PR TITLE
update giscus

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -50,6 +50,11 @@ comments:
     discussion_term      : # "pathname" (default), "url", "title", "og:title"
     reactions_enabled    : # '1' for enabled (default), '0' for disabled
     theme                : # "light" (default), "dark", "dark_dimmed", "transparent_dark", "preferred_color_scheme"
+    strict               : # 1 for enabled, 0 for disabled (default)
+    input_position       : # "top", "bottom" # The comment input box will be placed above or below the comments
+    emit_metadata        : # 1 for enabled, 0 for disabled (default) # https://github.com/giscus/giscus/blob/main/ADVANCED-USAGE.md#imetadatamessage
+    lang                 : # "en" (default)
+    lazy                 : # true, false # Loading of the comments will be deferred until the user scrolls near the comments container.
   staticman:
     branch               : # "master"
     endpoint             : # "https://{your Staticman v3 API}/v3/entry/github/"

--- a/_includes/comments-providers/giscus.html
+++ b/_includes/comments-providers/giscus.html
@@ -18,7 +18,7 @@
     script.setAttribute('data-mapping', '{{ site.comments.giscus.discussion_term | default: "pathname" }}');
     script.setAttribute('data-strict', '{{ site.comments.giscus.strict | default: 0 }}');
     script.setAttribute('data-reactions-enabled', '{{ site.comments.giscus.reactions_enabled | default: 1 }}');
-    script.setAttribute('data-emit-metadata', '{{ site.comments.giscus.emet_metadata | default: 0 }}');
+    script.setAttribute('data-emit-metadata', '{{ site.comments.giscus.emit_metadata | default: 0 }}');
     script.setAttribute('data-input-position', '{{ site.comments.giscus.input_position | default: "top" }}');
     script.setAttribute('data-theme', '{{ site.comments.giscus.theme | default: "light" }}');
     script.setAttribute('data-lang',  '{{ site.comments.giscus.lang | default: "en" }}');

--- a/_includes/comments-providers/giscus.html
+++ b/_includes/comments-providers/giscus.html
@@ -9,15 +9,25 @@
     }
 
     var script = document.createElement('script');
+
     script.setAttribute('src', 'https://giscus.app/client.js');
     script.setAttribute('data-repo', '{{ site.repository | downcase }}');
     script.setAttribute('data-repo-id', '{{ site.comments.giscus.repo_id }}');
     script.setAttribute('data-category', '{{ site.comments.giscus.category_name }}');
     script.setAttribute('data-category-id', '{{ site.comments.giscus.category_id }}');
     script.setAttribute('data-mapping', '{{ site.comments.giscus.discussion_term | default: "pathname" }}');
+    script.setAttribute('data-strict', '{{ site.comments.giscus.strict | default: 0 }}');
     script.setAttribute('data-reactions-enabled', '{{ site.comments.giscus.reactions_enabled | default: 1 }}');
+    script.setAttribute('data-emit-metadata', '{{ site.comments.giscus.emet_metadata | default: 0 }}');
+    script.setAttribute('data-input-position', '{{ site.comments.giscus.input_position | default: "top" }}');
     script.setAttribute('data-theme', '{{ site.comments.giscus.theme | default: "light" }}');
+    script.setAttribute('data-lang',  '{{ site.comments.giscus.lang | default: "en" }}');
+    {% if site.comments.giscus.lazy %}
+    script.setAttribute('data-loading', 'lazy');
+    {% endif %}
     script.setAttribute('crossorigin', 'anonymous');
+
+    script.setAttribute('async', '');
 
     commentContainer.appendChild(script);
   })();


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - Read the contributing document at https://github.com/mmistakes/minimal-mistakes#contributing
-->

<!--
  Choose one of the following by uncommenting it:
-->

<!-- This is a bug fix. -->
This is an enhancement or feature.
<!-- This is a documentation change. -->

## Summary

New attributes for the giscus comment provider

## Context

1. Configuration attributes:

- `data-emit-metadata` - Discussion metadata will be sent periodically to the parent window (the embedding page). For demonstration, enable this option and open your browser's console on this page. See [the documentation](https://github.com/giscus/giscus/blob/main/ADVANCED-USAGE.md#imetadatamessage) for more details.
- `data-input-position` - The comment input box will be placed above the comments, so that users can leave a comment without scrolling to the bottom of the discussion.
- `data-lang` - Interface language. 
- `data-loading` - Loading of the comments will be deferred until the user scrolls near the comments container. This is done by adding [loading="lazy"](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#attr-loading) to the <iframe> element.
- `data-strict` - Avoid mismatches due to GitHub's fuzzy searching method when there are multiple discussions with similar titles. See [the documentation](https://github.com/giscus/giscus/blob/main/ADVANCED-USAGE.md#data-strict) for more details.

2. `async` - HTML attribute for the `<script>` tag