### PR TITLE
Allow to optionally define website copyright holder name and url usin…

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -18,4 +18,4 @@
   </ul>
 </div>
 
-<div class="page__footer-copyright">&copy; {{ site.time | date: '%Y' }} {{ site.name | default: site.title }}. {{ site.data.ui-text[site.locale].powered_by | default: "Powered by" }} <a href="https://jekyllrb.com" rel="nofollow">Jekyll</a> &amp; <a href="https://mademistakes.com/work/minimal-mistakes-jekyll-theme/" rel="nofollow">Minimal Mistakes</a>.</div>
+<div class="page__footer-copyright">&copy; {{ site.time | date: '%Y' }} <a href="{{ site.copyright_url | default: site.url }}">{{ site.copyright | default: site.title }}</a>. {{ site.data.ui-text[site.locale].powered_by | default: "Powered by" }} <a href="https://jekyllrb.com" rel="nofollow">Jekyll</a> &amp; <a href="https://mademistakes.com/work/minimal-mistakes-jekyll-theme/" rel="nofollow">Minimal Mistakes</a>.</div>


### PR DESCRIPTION
…g site.copyright and site.copyright_url

<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - Read the contributing document at https://github.com/mmistakes/minimal-mistakes#contributing
-->

<!--
  Choose one of the following by uncommenting it:
-->

<!-- This is a bug fix. -->
This is an enhancement or feature. 
<!-- This is a documentation change. -->

## Summary

<!--
  Provide a description of what your pull request changes.
-->
In https://github.com/mmistakes/so-simple-theme you can edit the copyright statement by using the <tt>site.copyright</tt> variable. In https://github.com/mmistakes/minimal-mistakes it is hardcoded in <tt>_includes/footer.html</tt> to use the <tt>site.url</tt> and <tt>site.title</tt>. 

The proposed change modifies <tt>_includes/footer.html</tt> and creates two variables --  <tt>site.copyright_url</tt> and <tt>site.copyright</tt> -- which if defined, say

<pre>title: My Awesome site
copyright: I did it
copyright_url: "https://example.com"
</pre>

use them instead. Note that neither need to exist: one can have <tt>site.copyright_url</tt> without <tt>site.copyright</tt> or vice-versa.

## Context

<!--
  Is this related to any GitHub issue(s)?
-->
This is not related to any GitHub issue at all.

