### PR TITLE
Renamed navigation item to docs and samples

### DIFF
--- a/docs/_data/navigation.yml
+++ b/docs/_data/navigation.yml
@@ -26,7 +26,7 @@ main:
     url: /about/
   - title: "Sample Posts"
     url: /year-archive/
-  - title: "Sample Collections"
+  - title: "Docs &amp; Samples"
     url: /collection-archive/
   - title: "Terms &amp; Privacy Policy"
     url: /terms/


### PR DESCRIPTION
<!-- This is an enhancement or feature. -->

## Summary

I searched for the docs and found this great documentation under Sample Collection. It was not intuitive. So I suggest renaming it to Docs & Samples.  I did not change the url to avoid broken links.


