### PR TITLE
Add Devcontainer for Jekyll build

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,31 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/jekyll
+{
+	"name": "Jekyll",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/jekyll:0-bullseye",
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Configure tool-specific properties.
+	"customizations": {
+		// Configure properties specific to VS Code.
+		"vscode": {
+			"settings": {},
+			"extensions": [
+				"streetsidesoftware.code-spell-checker",
+				"DavidAnson.vscode-markdownlint"
+			]
+		}
+	},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	"forwardPorts": [4000]
+
+	// Uncomment the next line to run commands after the container is created.
+	// "postCreateCommand": "jekyll --version"
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}


### PR DESCRIPTION
This is an enhancement or feature.

## Summary

As a developer, I want to keep my projects' dependencies isolated during development.

## Context

This is a quality of life improvement for developers consuming this project.

## The What

Visual Studio Code is my IDE of choice when working FOSS projects. It has support for containerized development with very little configuration on the developer's side.

## How

To use this, simply install the following:

- VS Code
- Containerized Development Extension
- Docker

Then, open the container with VSCode. You should be prompted to "Reopen in a container".

This config automatically takes care of port forwarding for you.