### PR TITLE
Update to font-awesome v6 (more icons)

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -15,8 +15,8 @@
 
 <!-- For all browsers -->
 <link rel="stylesheet" href="{{ '/assets/css/main.css' | relative_url }}">
-<link rel="preload" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@5/css/all.min.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
-<noscript><link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@5/css/all.min.css"></noscript>
+<link rel="preload" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6/css/all.min.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
+<noscript><link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6/css/all.min.css"></noscript>
 
 {% if site.head_scripts %}
   {% for script in site.head_scripts %}


### PR DESCRIPTION

<!--
  - Read the contributing document at https://github.com/mmistakes/minimal-mistakes#contributing
  - [x] Done!
-->

<!-- This is an enhancement or feature. -->

## Summary

Update to font-awesome v6 (more icons)

## Context

I saw that in the past you've used [kit.fontawesome.com](https://kit.fontawesome.com/4eee35f757.js) (issue #2184) but then have reverted to the hard-coded version. Not sure if this should instead use the kit feature again, but in the mean time - updating to v6 allows using all the free icons documented on fontawesome's website. These are available on the linked CDN and `@fortawesome`.