### PR TITLE
Remove redundant downcase from _layouts/categories.html

### DIFF
--- a/_layouts/categories.html
+++ b/_layouts/categories.html
@@ -29,7 +29,7 @@ layout: archive
 {% for i in (1..categories_max) reversed %}
   {% for category in site.categories %}
     {% if category[1].size == i %}
-      <section id="{{ category[0] | slugify | downcase }}" class="taxonomy__section">
+      <section id="{{ category[0] | slugify }}" class="taxonomy__section">
         <h2 class="archive__subtitle">{{ category[0] }}</h2>
         <div class="entries-{{ entries_layout }}">
           {% for post in category.last %}


### PR DESCRIPTION
abundant code

<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - Read the contributing document at https://github.com/mmistakes/minimal-mistakes#contributing
-->

<!--
  Choose one of the following by uncommenting it:
-->

<!-- This is a bug fix. -->
This is an enhancement or feature.
<!-- This is a documentation change. -->

## Summary

    {{ "ABCD" |  slugify }}
    abcd

<!--
  Provide a description of what your pull request changes.
-->

## Context

<!--
  Is this related to any GitHub issue(s)?
-->
"slugify" filter calls "Utils.slugfy" without "cased" parameter,
which set to "false" default value.

          slug.downcase! unless cased

So "downcase" filter following "slugify seems rebundant.

https://github.com/jekyll/jekyll/blob/master/lib/jekyll/filters.rb#L62

https://github.com/jekyll/jekyll/blob/master/lib/jekyll/utils.rb#L202