### PR TITLE
Fix Linkedin social share link

### DIFF
--- a/_includes/social-share.html
+++ b/_includes/social-share.html
@@ -7,5 +7,5 @@
 
   <a href="https://www.facebook.com/sharer/sharer.php?u={{ page.url | absolute_url | url_encode }}" class="btn btn--facebook" onclick="window.open(this.href, 'window', 'left=20,top=20,width=500,height=500,toolbar=1,resizable=0'); return false;" title="{{ site.data.ui-text[site.locale].share_on_label | default: 'Share on' }} Facebook"><i class="fab fa-fw fa-facebook" aria-hidden="true"></i><span> Facebook</span></a>
 
-  <a href="https://www.linkedin.com/shareArticle?mini=true&url={{ page.url | absolute_url | url_encode }}" class="btn btn--linkedin" onclick="window.open(this.href, 'window', 'left=20,top=20,width=500,height=500,toolbar=1,resizable=0'); return false;" title="{{ site.data.ui-text[site.locale].share_on_label | default: 'Share on' }} LinkedIn"><i class="fab fa-fw fa-linkedin" aria-hidden="true"></i><span> LinkedIn</span></a>
+  <a href="https://www.linkedin.com/shareArticle?mini=true&url={{ page.url | absolute_url }}" class="btn btn--linkedin" onclick="window.open(this.href, 'window', 'left=20,top=20,width=500,height=500,toolbar=1,resizable=0'); return false;" title="{{ site.data.ui-text[site.locale].share_on_label | default: 'Share on' }} LinkedIn"><i class="fab fa-fw fa-linkedin" aria-hidden="true"></i><span> LinkedIn</span></a>
 </section>


### PR DESCRIPTION
Removed url encoding of the article link

<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - Read the contributing document at https://github.com/mmistakes/minimal-mistakes#contributing
-->

<!--
  Choose one of the following by uncommenting it:
-->

This is a bug fix.
<!-- This is an enhancement or feature. -->
<!-- This is a documentation change. -->

## Summary

<!--
  Provide a description of what your pull request changes.
-->
Linkedin social share button does not seem to be working correctly when an article's URL is encoded (as in `/` replaced with `%2F` etc). I encountered this bug while trying to share my own article hosted on Github Pages. It does not seem to be the case with common websites, for example `https://google.com/` seems to work both raw and encoded.

## Context

<!--
  Is this related to any GitHub issue(s)?
-->
I didn't find any issue mentioning that bug - but the fix is quick and simple enough to go with the PR right away.