### PR TITLE
Remove deprecated "page.header.cta_url" setting

### DIFF
--- a/_includes/page__hero.html
+++ b/_includes/page__hero.html
@@ -36,9 +36,6 @@
         <p class="page__lead">{{ page.excerpt | markdownify | remove: "<p>" | remove: "</p>" }}</p>
       {% endif %}
       {% include page__meta.html %}
-      {% if page.header.cta_url %}
-        <p><a href="{{ page.header.cta_url | relative_url }}" class="btn btn--light-outline btn--large">{{ page.header.cta_label | default: site.data.ui-text[site.locale].more_label | default: "Learn More" }}</a></p>
-      {% endif %}
       {% if page.header.actions %}
         <p>
         {% for action in page.header.actions %}

--- a/docs/_docs/10-layouts.md
+++ b/docs/_docs/10-layouts.md
@@ -463,8 +463,6 @@ To overlay text on top of a header image you have a few more options:
 | **excerpt**              | Auto-generated page excerpt is added to the overlay text or can be overridden. | |
 | **tagline**              | Overrides page excerpt. Useful when header text needs to be different from excerpt in archive views. | |
 | **actions**              | Call to action button links (`actions` array: `label` and `url`). More than one button link can be assigned. | |
-| **cta_label**            | Deprecated, use `actions` instead. Call to action button text label. | `more_label` in UI Text data file |
-| **cta_url**              | Deprecated, use `actions` instead. Call to action button URL. | |
 
   [mdn-linear-gradient]: https://developer.mozilla.org/en-US/docs/Web/CSS/linear-gradient()
 


### PR DESCRIPTION
Found this lying around while doing bde92b6d4aa00209f41de1d855473d779e0c6a2b. Thought I'd just remove it but hesitated for these reasons:

- I'm a fan of [Semantic Versioning](https://semver.org/) and this is a breaking change for existing users.
    - [Material for MkDocs](https://squidfunk.github.io/minimal-mistakes/) is another theme that I use extensively, and it's doing a great job of following SemVer.
- Too minor a change for bumping the "major" version (i.e. v5.0.0).
	- As far as I understand, a website theme is intended as a "root dependency" (facing end users directly), so there was no plan to follow SemVer from the beginning. The "major" version of this project is thus intended as "major overhauls" or "reincarnations (not really)".

Context:

- Already deprecated since [4.13.0](https://github.com/mmistakes/minimal-mistakes/releases/tag/4.13.0) (September 2018).
- [Not many sites would be affected](https://github.com/search?q=%22cta_url%3A%22&type=code): I glanced through the search results and there's not many *live* sites using Gemfile with MM version specified as `"~> 4.something"` (i.e. audience of SemVer).

    Most repos are full forks so they're not affected, and those who use the remote theme method without specifying a version will be affected nevertheless (regardless of whether we bump the version number).

Given the considerations above, I'm inclined to push this forward. Though for the first time of doing this, I'd like to ask for your input, @mmistakes.