### PR TITLE
Page locale

### DIFF
--- a/_includes/archive-single.html
+++ b/_includes/archive-single.html
@@ -11,7 +11,7 @@
 {% endif %}
 
 <div class="{{ include.type | default: 'list' }}__item">
-  <article class="archive__item" itemscope itemtype="https://schema.org/CreativeWork"{% if page.locale %} lang="{{ post.locale | default: site.locale | replace: "_", "-" | default: "en" }}"{% endif %}>
+  <article class="archive__item" itemscope itemtype="https://schema.org/CreativeWork"{% if post.locale %} lang="{{ post.locale }}"{% endif %}>
     {% if include.type == "grid" and teaser %}
       <div class="archive__item-teaser">
         <img src="{{ teaser | relative_url }}" alt="">

--- a/_includes/archive-single.html
+++ b/_includes/archive-single.html
@@ -11,7 +11,7 @@
 {% endif %}
 
 <div class="{{ include.type | default: 'list' }}__item">
-  <article class="archive__item" itemscope itemtype="https://schema.org/CreativeWork" lang="{{ post.locale | default: site.locale | replace: "_", "-" | default: "en" }}">
+  <article class="archive__item" itemscope itemtype="https://schema.org/CreativeWork"{% if page.locale %} lang="{{ post.locale | default: site.locale | replace: "_", "-" | default: "en" }}"{% endif %}>
     {% if include.type == "grid" and teaser %}
       <div class="archive__item-teaser">
         <img src="{{ teaser | relative_url }}" alt="">

--- a/_includes/archive-single.html
+++ b/_includes/archive-single.html
@@ -11,7 +11,7 @@
 {% endif %}
 
 <div class="{{ include.type | default: 'list' }}__item">
-  <article class="archive__item" itemscope itemtype="https://schema.org/CreativeWork">
+  <article class="archive__item" itemscope itemtype="https://schema.org/CreativeWork" lang="{{ post.locale | default: site.locale | replace: "_", "-" | default: "en" }}">
     {% if include.type == "grid" and teaser %}
       <div class="archive__item-teaser">
         <img src="{{ teaser | relative_url }}" alt="">

--- a/_includes/breadcrumbs.html
+++ b/_includes/breadcrumbs.html
@@ -26,7 +26,7 @@
         <span class="sep">{{ site.data.ui-text[site.locale].breadcrumb_separator | default: "/" }}</span>
       {% endif %}
       {% if forloop.last %}
-        <li class="current"{% if page.locale %} lang="{{ page.locale | default: site.locale | replace: "_", "-" | default: "en" }}"{% endif %}>{{ page.title }}</li>
+        <li class="current"{% if page.locale %} lang="{{ page.locale }}"{% endif %}>{{ page.title }}</li>
       {% else %}
         {% assign i = i | plus: 1 %}
         <li itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">

--- a/_includes/breadcrumbs.html
+++ b/_includes/breadcrumbs.html
@@ -26,7 +26,7 @@
         <span class="sep">{{ site.data.ui-text[site.locale].breadcrumb_separator | default: "/" }}</span>
       {% endif %}
       {% if forloop.last %}
-        <li class="current">{{ page.title }}</li>
+        <li class="current" lang="{{ page.locale | default: site.locale | replace: "_", "-" | default: "en" }}">{{ page.title }}</li>
       {% else %}
         {% assign i = i | plus: 1 %}
         <li itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">

--- a/_includes/breadcrumbs.html
+++ b/_includes/breadcrumbs.html
@@ -26,7 +26,7 @@
         <span class="sep">{{ site.data.ui-text[site.locale].breadcrumb_separator | default: "/" }}</span>
       {% endif %}
       {% if forloop.last %}
-        <li class="current" lang="{{ page.locale | default: site.locale | replace: "_", "-" | default: "en" }}">{{ page.title }}</li>
+        <li class="current"{% if page.locale %} lang="{{ page.locale | default: site.locale | replace: "_", "-" | default: "en" }}"{% endif %}>{{ page.title }}</li>
       {% else %}
         {% assign i = i | plus: 1 %}
         <li itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">

--- a/_layouts/archive-taxonomy.html
+++ b/_layouts/archive-taxonomy.html
@@ -20,7 +20,7 @@ author_profile: false
 
   <div class="archive">
     {% unless page.header.overlay_color or page.header.overlay_image %}
-      <h1 id="page-title" class="page__title" lang="{{ page.locale | default: site.locale | replace: "_", "-" | default: "en" }}">{{ page.title }}</h1>
+      <h1 id="page-title" class="page__title"{% if page.locale %} lang="{{ page.locale | default: site.locale | replace: "_", "-" | default: "en" }}"{% endif %}>{{ page.title }}</h1>
     {% endunless %}
     {% for post in page.posts %}
       {% include archive-single.html %}

--- a/_layouts/archive-taxonomy.html
+++ b/_layouts/archive-taxonomy.html
@@ -20,7 +20,7 @@ author_profile: false
 
   <div class="archive">
     {% unless page.header.overlay_color or page.header.overlay_image %}
-      <h1 id="page-title" class="page__title"{% if page.locale %} lang="{{ page.locale | default: site.locale | replace: "_", "-" | default: "en" }}"{% endif %}>{{ page.title }}</h1>
+      <h1 id="page-title" class="page__title"{% if page.locale %} lang="{{ page.locale }}"{% endif %}>{{ page.title }}</h1>
     {% endunless %}
     {% for post in page.posts %}
       {% include archive-single.html %}

--- a/_layouts/archive-taxonomy.html
+++ b/_layouts/archive-taxonomy.html
@@ -20,7 +20,7 @@ author_profile: false
 
   <div class="archive">
     {% unless page.header.overlay_color or page.header.overlay_image %}
-      <h1 id="page-title" class="page__title">{{ page.title }}</h1>
+      <h1 id="page-title" class="page__title" lang="{{ page.locale | default: site.locale | replace: "_", "-" | default: "en" }}">{{ page.title }}</h1>
     {% endunless %}
     {% for post in page.posts %}
       {% include archive-single.html %}

--- a/_layouts/archive.html
+++ b/_layouts/archive.html
@@ -19,7 +19,7 @@ layout: default
 
   <div class="archive">
     {% unless page.header.overlay_color or page.header.overlay_image %}
-      <h1 id="page-title" class="page__title" lang="{{ page.locale | default: site.locale | replace: "_", "-" | default: "en" }}">{{ page.title }}</h1>
+      <h1 id="page-title" class="page__title"{% if page.locale %} lang="{{ page.locale | default: site.locale | replace: "_", "-" | default: "en" }}"{% endif %}>{{ page.title }}</h1>
     {% endunless %}
     {{ content }}
   </div>

--- a/_layouts/archive.html
+++ b/_layouts/archive.html
@@ -19,7 +19,7 @@ layout: default
 
   <div class="archive">
     {% unless page.header.overlay_color or page.header.overlay_image %}
-      <h1 id="page-title" class="page__title"{% if page.locale %} lang="{{ page.locale | default: site.locale | replace: "_", "-" | default: "en" }}"{% endif %}>{{ page.title }}</h1>
+      <h1 id="page-title" class="page__title"{% if page.locale %} lang="{{ page.locale }}"{% endif %}>{{ page.title }}</h1>
     {% endunless %}
     {{ content }}
   </div>

--- a/_layouts/archive.html
+++ b/_layouts/archive.html
@@ -19,7 +19,7 @@ layout: default
 
   <div class="archive">
     {% unless page.header.overlay_color or page.header.overlay_image %}
-      <h1 id="page-title" class="page__title">{{ page.title }}</h1>
+      <h1 id="page-title" class="page__title" lang="{{ page.locale | default: site.locale | replace: "_", "-" | default: "en" }}">{{ page.title }}</h1>
     {% endunless %}
     {{ content }}
   </div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -3,7 +3,7 @@
 
 <!doctype html>
 {% include copyright.html %}
-<html lang="{{ site.locale | slice: 0,2 | default: "en" }}" class="no-js">
+<html lang="{{ site.locale | replace: "_", "-" | default: "en" }}" class="no-js">
   <head>
     {% include head.html %}
     {% include head/custom.html %}

--- a/_layouts/search.html
+++ b/_layouts/search.html
@@ -17,7 +17,7 @@ layout: default
 
   <div class="archive">
     {% unless page.header.overlay_color or page.header.overlay_image %}
-      <h1 id="page-title" class="page__title"{% if page.locale %} lang="{{ page.locale | default: site.locale | replace: "_", "-" | default: "en" }}"{% endif %}>{{ page.title }}</h1>
+      <h1 id="page-title" class="page__title"{% if page.locale %} lang="{{ page.locale }}"{% endif %}>{{ page.title }}</h1>
     {% endunless %}
 
     {{ content }}

--- a/_layouts/search.html
+++ b/_layouts/search.html
@@ -17,7 +17,7 @@ layout: default
 
   <div class="archive">
     {% unless page.header.overlay_color or page.header.overlay_image %}
-      <h1 id="page-title" class="page__title">{{ page.title }}</h1>
+      <h1 id="page-title" class="page__title" lang="{{ page.locale | default: site.locale | replace: "_", "-" | default: "en" }}">{{ page.title }}</h1>
     {% endunless %}
 
     {{ content }}

--- a/_layouts/search.html
+++ b/_layouts/search.html
@@ -17,7 +17,7 @@ layout: default
 
   <div class="archive">
     {% unless page.header.overlay_color or page.header.overlay_image %}
-      <h1 id="page-title" class="page__title" lang="{{ page.locale | default: site.locale | replace: "_", "-" | default: "en" }}">{{ page.title }}</h1>
+      <h1 id="page-title" class="page__title"{% if page.locale %} lang="{{ page.locale | default: site.locale | replace: "_", "-" | default: "en" }}"{% endif %}>{{ page.title }}</h1>
     {% endunless %}
 
     {{ content }}

--- a/_layouts/single.html
+++ b/_layouts/single.html
@@ -21,7 +21,7 @@ layout: default
 <div id="main" role="main">
   {% include sidebar.html %}
 
-  <article class="page" itemscope itemtype="https://schema.org/CreativeWork"{% if page.locale %} lang="{{ page.locale | default: site.locale | replace: "_", "-" | default: "en" }}"{% endif %}>
+  <article class="page" itemscope itemtype="https://schema.org/CreativeWork"{% if page.locale %} lang="{{ page.locale }}"{% endif %}>
     {% if page.title %}<meta itemprop="headline" content="{{ page.title | replace: '|', '&#124;' | markdownify | strip_html | strip_newlines | escape_once }}">{% endif %}
     {% if page.excerpt %}<meta itemprop="description" content="{{ page.excerpt | markdownify | strip_html | strip_newlines | escape_once }}">{% endif %}
     {% if page.date %}<meta itemprop="datePublished" content="{{ page.date | date_to_xmlschema }}">{% endif %}

--- a/_layouts/single.html
+++ b/_layouts/single.html
@@ -21,7 +21,7 @@ layout: default
 <div id="main" role="main">
   {% include sidebar.html %}
 
-  <article class="page" itemscope itemtype="https://schema.org/CreativeWork">
+  <article class="page" itemscope itemtype="https://schema.org/CreativeWork" lang="{{ page.locale | default: site.locale | replace: "_", "-" | default: "en" }}">
     {% if page.title %}<meta itemprop="headline" content="{{ page.title | replace: '|', '&#124;' | markdownify | strip_html | strip_newlines | escape_once }}">{% endif %}
     {% if page.excerpt %}<meta itemprop="description" content="{{ page.excerpt | markdownify | strip_html | strip_newlines | escape_once }}">{% endif %}
     {% if page.date %}<meta itemprop="datePublished" content="{{ page.date | date_to_xmlschema }}">{% endif %}

--- a/_layouts/single.html
+++ b/_layouts/single.html
@@ -21,7 +21,7 @@ layout: default
 <div id="main" role="main">
   {% include sidebar.html %}
 
-  <article class="page" itemscope itemtype="https://schema.org/CreativeWork" lang="{{ page.locale | default: site.locale | replace: "_", "-" | default: "en" }}">
+  <article class="page" itemscope itemtype="https://schema.org/CreativeWork"{% if page.locale %} lang="{{ page.locale | default: site.locale | replace: "_", "-" | default: "en" }}"{% endif %}>
     {% if page.title %}<meta itemprop="headline" content="{{ page.title | replace: '|', '&#124;' | markdownify | strip_html | strip_newlines | escape_once }}">{% endif %}
     {% if page.excerpt %}<meta itemprop="description" content="{{ page.excerpt | markdownify | strip_html | strip_newlines | escape_once }}">{% endif %}
     {% if page.date %}<meta itemprop="datePublished" content="{{ page.date | date_to_xmlschema }}">{% endif %}

--- a/_layouts/splash.html
+++ b/_layouts/splash.html
@@ -9,7 +9,7 @@ layout: default
 {% endif %}
 
 <div id="main" role="main">
-  <article class="splash" itemscope itemtype="https://schema.org/CreativeWork"{% if page.locale %} lang="{{ page.locale | default: site.locale | replace: "_", "-" | default: "en" }}"{% endif %}>
+  <article class="splash" itemscope itemtype="https://schema.org/CreativeWork"{% if page.locale %} lang="{{ page.locale }}"{% endif %}>
     {% if page.title %}<meta itemprop="headline" content="{{ page.title | markdownify | strip_html | strip_newlines | escape_once }}">{% endif %}
     {% if page.excerpt %}<meta itemprop="description" content="{{ page.excerpt | markdownify | strip_html | strip_newlines | escape_once }}">{% endif %}
     {% if page.date %}<meta itemprop="datePublished" content="{{ page.date | date_to_xmlschema }}">{% endif %}

--- a/_layouts/splash.html
+++ b/_layouts/splash.html
@@ -9,7 +9,7 @@ layout: default
 {% endif %}
 
 <div id="main" role="main">
-  <article class="splash" itemscope itemtype="https://schema.org/CreativeWork" lang="{{ page.locale | default: site.locale | replace: "_", "-" | default: "en" }}">
+  <article class="splash" itemscope itemtype="https://schema.org/CreativeWork"{% if page.locale %} lang="{{ page.locale | default: site.locale | replace: "_", "-" | default: "en" }}"{% endif %}>
     {% if page.title %}<meta itemprop="headline" content="{{ page.title | markdownify | strip_html | strip_newlines | escape_once }}">{% endif %}
     {% if page.excerpt %}<meta itemprop="description" content="{{ page.excerpt | markdownify | strip_html | strip_newlines | escape_once }}">{% endif %}
     {% if page.date %}<meta itemprop="datePublished" content="{{ page.date | date_to_xmlschema }}">{% endif %}

--- a/_layouts/splash.html
+++ b/_layouts/splash.html
@@ -9,7 +9,7 @@ layout: default
 {% endif %}
 
 <div id="main" role="main">
-  <article class="splash" itemscope itemtype="https://schema.org/CreativeWork">
+  <article class="splash" itemscope itemtype="https://schema.org/CreativeWork" lang="{{ page.locale | default: site.locale | replace: "_", "-" | default: "en" }}">
     {% if page.title %}<meta itemprop="headline" content="{{ page.title | markdownify | strip_html | strip_newlines | escape_once }}">{% endif %}
     {% if page.excerpt %}<meta itemprop="description" content="{{ page.excerpt | markdownify | strip_html | strip_newlines | escape_once }}">{% endif %}
     {% if page.date %}<meta itemprop="datePublished" content="{{ page.date | date_to_xmlschema }}">{% endif %}


### PR DESCRIPTION
This is a feature. 

## Summary

This PR allows for a page to specify a content `locale` that is used only for _that one_ page.

Compared to the similar PR https://github.com/mmistakes/minimal-mistakes/pull/4679,  this set of changes is relatively small, as I am not going for localising anything. Instead, the focus is on expressing the _actual_ locale of the content, as it is written in the page and declared as `locale` in the front matter, in the containing element's `lang` attribute.

Fallback to `site.locale` is present where applicable.

This PR has an associated commit that writes the site locale (`lang` attribute of the `html` element) in the style the W3C recommends (language and region separated by dash), instead of just cutting off the region. Let me know if you'd prefer this one as a separate PR.

## Context

I am running [my blog](https://uhlig.it) mostly in English, but a few pages are in German. I am running a spell checker across all pages before publishing them, and having an accurate locale on each page is crucial for that.

## Example

A site that has `locale: en_US` in its `_config.yaml` generates the following `html` element:

```html
<html lang="en-US" ...>
```

A page may specify that its content is written in German:

```markdown
---
title: Eine Seite in Deutsch
locale: de_DE
---

Das ist der Inhalt...
```

With this PR, the rendered HTML looks like this:

```html
<html lang="en-US"...>
<article class="page" ... lang="de-DE">
  <h1>Eine Seite in Deutsch</h1>
  ...
```

Everything is still being treated as written in the site's locale `en-US`, but this one page declares its main content correctly as `de-DE`.