### PR TITLE
The "if" means the default is never used

### DIFF
--- a/_includes/social-share.html
+++ b/_includes/social-share.html
@@ -1,7 +1,5 @@
 <section class="page__share">
-  {% if site.data.ui-text[site.locale].share_on_label %}
-    <h4 class="page__share-title">{{ site.data.ui-text[site.locale].share_on_label | default: "Share on" }}</h4>
-  {% endif %}
+  <h4 class="page__share-title">{{ site.data.ui-text[site.locale].share_on_label | default: "Share on" }}</h4>
 
   <a href="https://twitter.com/intent/tweet?{% if site.twitter.username %}via={{ site.twitter.username | url_encode }}&{% endif %}text={{ page.title | url_encode }}%20{{ page.url | absolute_url | url_encode }}" class="btn btn--twitter" onclick="window.open(this.href, 'window', 'left=20,top=20,width=500,height=500,toolbar=1,resizable=0'); return false;" title="{{ site.data.ui-text[site.locale].share_on_label | default: 'Share on' }} Twitter"><i class="fab fa-fw fa-twitter" aria-hidden="true"></i><span> Twitter</span></a>
 


### PR DESCRIPTION
This is a bug fix. 

## Summary

Fixes the social share include so the default text works as expected.

## Context

The current code looks like this:

      {% if site.data.ui-text[site.locale].share_on_label %}
        <h4 class="page__share-title">{{ site.data.ui-text[site.locale].share_on_label | default: "Share on" }}</h4>
      {% endif %}

The `if` statement means that the default ("Share on") is never used. And I assume that's what most people would want to see.

Also, without the `<h4>`, we get a HTML validation warning - as the `<section class="page__share">` has no header.

Just removing the `if`/`endif` lines fixes these problems without changing the behaviour.
