### PR TITLE
Remove unnecessary "type" attribute

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -9,7 +9,7 @@
 {%- comment %} https://docs.google.com/presentation/d/1rmxwWa9P6_xHqonmh5ONXRS-jPc5XKbnv99Rjkhe04s/present {% endcomment -%}
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-<script type="text/javascript">
+<script>
   document.documentElement.className = document.documentElement.className.replace(/\bno-js\b/g, '') + ' js ';
   {% if site.enable_copy_code_button -%}
     window.enable_copy_code_button = true;


### PR DESCRIPTION
This is an enhancement or feature. 

## Summary

The `<script>` in `_includes/head.html` had a `type=text/javascript` attribute which was unnecessary and gives a warning in an HTML validator.

This pull request removes that.

## Context

Valid HTML is always a good idea :-)
