### PR TITLE
Fix: Prevent double title issue in SEO metadata by updating seo.html

### DIFF
--- a/_includes/seo.html
+++ b/_includes/seo.html
@@ -2,7 +2,11 @@
 {%- assign title_separator = site.title_separator | default: '-' -%}
 
 {%- assign page_title = page.title | default: site.title | replace: '|', '&#124;' -%}
-{%- assign seo_title = page_title | append: " " | append: title_separator | append: " " | append: site.title | replace: '|', '&#124;' -%}
+{%- if page_title contains site.title -%}
+  {%- assign seo_title = page_title | replace: '|', '&#124;' -%}
+{%- else -%}
+  {%- assign seo_title = page_title | append: " " | append: title_separator | append: " " | append: site.title | replace: '|', '&#124;' -%}
+{%- endif -%}
 
 {%- assign page_title = page_title | markdownify | strip_html | strip_newlines | escape_once -%}
 {%- assign seo_title  = seo_title  | markdownify | strip_html | strip_newlines | escape_once -%}


### PR DESCRIPTION
This is a bug fix.


## Summary
This pull request addresses the issue of duplicated titles in the SEO metadata. The fix involves overriding the seo.html file and     updating the logic to ensure the page title doesn't include the site title twice. The change ensures that the title displayed in the     browser tab and metadata is clean and correctly formatted.

Changes Include:
- Created a custom _includes/seo.html file.
- Updated the logic in seo.html to prevent the page title from containing the site title twice.

Testing:
- Verified that the title is no longer duplicated in the browser tab and in the generated HTML meta tags.
