### PR TITLE
Hide hidden links & remove the overlay when one is clicked

### DIFF
--- a/assets/js/plugins/jquery.greedy-navigation.js
+++ b/assets/js/plugins/jquery.greedy-navigation.js
@@ -103,7 +103,11 @@ $(function() {
     clearTimeout(timer);
   });
 
-  $hlinks.on('mouseleave', function() {
+  $hlinks.on("click", function () {
+    // Hide the hidden links & remove the overlay when one is clicked.
+    $hlinks.addClass("hidden");
+    $btn.removeClass("close");
+  }).on('mouseleave', function() {
     // Mouse has left, start the timer
     timer = setTimeout(function() {
       $hlinks.addClass('hidden');


### PR DESCRIPTION
This is a bug fix.

## Summary

When a "hidden" nav bar link is clicked in a mobile view, the overlay doesn't go away. You'll only notice if the link is to an on-page location.

See [this video](https://www.loom.com/share/987f39548b7443f3a1df903f472f8849?sid=f7684184-c1d5-4cbb-895f-3ff06087afbf) for a walkthrough of the issue and an easy front-end fix. The script in the fix looks like this:

```js
$(function () {
  var $btn = $("nav.greedy-nav .greedy-nav__toggle");
  var $hlinks = $("nav.greedy-nav .hidden-links");

  // Window listeners
  $hlinks.on("click", function () {
    $hlinks.addClass("hidden");
    $btn.removeClass("close");
  });
});
```

This PR applies the fix directly to the plugin code.

## Context

See issue #4537 

