### PR TITLE
icon color: bluesky, instagram, threads, tiktok, x, youtube

### DIFF
--- a/_sass/minimal-mistakes/_utilities.scss
+++ b/_sass/minimal-mistakes/_utilities.scss
@@ -201,13 +201,14 @@ $text-alignments: left, right, start, end, center, justify;
   @each $color, $icons in (
     $behance-color: ".fa-behance, .fa-behance-square",
     $bitbucket-color: ".fa-bitbucket",
+    $bluesky-color: ".fa-bluesky, .fa-square-bluesky",
     $dribbble-color: ".fa-dribbble, .fa-dribbble-square",
     $facebook-color: ".fa-facebook, .fa-facebook-square, .fa-facebook-f",
     $flickr-color: ".fa-flickr",
     $foursquare-color: ".fa-foursquare",
     $github-color: ".fa-github, .fa-github-alt, .fa-github-square",
     $gitlab-color: ".fa-gitlab",
-    $instagram-color: ".fa-instagram",
+    $instagram-color: ".fa-instagram, .fa-square-instagram",
     $keybase-color: ".fa-keybase",
     $lastfm-color: ".fa-lastfm, .fa-lastfm-square",
     $linkedin-color: ".fa-linkedin, .fa-linkedin-in",
@@ -223,6 +224,7 @@ $text-alignments: left, right, start, end, center, justify;
     $vine-color: ".fa-vine",
     $xing-color: ".fa-xing, .fa-xing-square",
     $youtube-color: ".fa-youtube",
+    $black-color: ".fa-x-twitter, .fa-square-x-twitter, .fa-threads, .fa-square-treads, .fa-tiktok",    
   ) {
     #{$icons} {
       color: $color;

--- a/_sass/minimal-mistakes/_variables.scss
+++ b/_sass/minimal-mistakes/_variables.scss
@@ -90,13 +90,14 @@ $yiq-debug: false !default;
 /* brands */
 $behance-color: #1769ff !default;
 $bitbucket-color: #205081 !default;
+$bluesky-color: #1185FE !default;
 $dribbble-color: #ea4c89 !default;
 $facebook-color: #3b5998 !default;
 $flickr-color: #ff0084 !default;
 $foursquare-color: #0072b1 !default;
 $github-color: #171516 !default;
 $gitlab-color: #e24329 !default;
-$instagram-color: #517fa4 !default;
+$instagram-color: #cd3376 !default;
 $keybase-color: #ef7639 !default;
 $lastfm-color: #d51007 !default;
 $linkedin-color: #007bb6 !default;
@@ -110,8 +111,9 @@ $tumblr-color: #32506d !default;
 $twitter-color: #55acee !default;
 $vimeo-color: #1ab7ea !default;
 $vine-color: #00bf8f !default;
-$youtube-color: #bb0000 !default;
 $xing-color: #006567 !default;
+$youtube-color: #bb0000 !default;
+$black-color: #000000 !default;
 
 /* links */
 $link-color: mix(#000, $info-color, 20%) !default;


### PR DESCRIPTION
This is an enhancement or feature.

## Summary

Positioned the brand icon below in alphabetical order

- youtube

Added color for the brand icon below

- blueskey

Modified the color for the brand icon below

- instagram

Added a square class to the brand icon below

- instagram

Color crashed for the brand icon below, so I consolidated it into one setting

- threads
- tiktok
- x