### PR TITLE
Fix typo in docs/_docs/05-configuration.md

### DIFF
--- a/docs/_docs/05-configuration.md
+++ b/docs/_docs/05-configuration.md
@@ -1232,7 +1232,7 @@ If you care at all about performance (and really who doesn't) compressing the HT
 
 If you're hosting with GitHub Pages there aren't many options afforded to you for optimizing the HTML Jekyll generates. Thankfully there is some Liquid wizardry you can use to strip whitespace and comments to reduce file size.
 
-There's a variety of configurations and caveats to using the `compress` layout, so be sure to read through the [documentation](http://jch.penibelst.de/) if you decide to make change the defaults set in the theme's `_config.yml`.
+There's a variety of configurations and caveats to using the `compress` layout, so be sure to read through the [documentation](http://jch.penibelst.de/) if you decide to change the defaults set in the theme's `_config.yml`.
 
 ```yaml
 compress_html:


### PR DESCRIPTION
This is a documentation change.

## Summary

Fixes a typo I found while reading through the docs.

## Context

Is this related to any GitHub issue(s)?

-> No

