### PR TITLE
Mastodon button color

### DIFF
--- a/_sass/minimal-mistakes/_buttons.scss
+++ b/_sass/minimal-mistakes/_buttons.scss
@@ -39,7 +39,8 @@
   (info, $info-color),
   (facebook, $facebook-color),
   (twitter, $twitter-color),
-  (linkedin, $linkedin-color);
+  (linkedin, $linkedin-color),
+  (mastodon, $mastodon-color);
 
   @each $buttoncolor, $color in $buttoncolors {
     &--#{$buttoncolor} {


### PR DESCRIPTION
This is a bug fix

## Summary

Add mastodon-color to the buttons scss file. The color code is already present, just not defined as a button.

## Context

I'm working on adding a 'share to mastodon' and was looking for the right colors. 