### PR TITLE
Tweak contrast skin $primary-color to adhere to WCAG guidelines

### DIFF
--- a/_sass/minimal-mistakes/skins/_contrast.scss
+++ b/_sass/minimal-mistakes/skins/_contrast.scss
@@ -5,7 +5,7 @@
 /* Colors */
 $text-color: #000 !default;
 $muted-text-color: $text-color !default;
-$primary-color: #ff0000 !default;
+$primary-color: #b60000 !default;
 $border-color: mix(#fff, $text-color, 75%) !default;
 $footer-background-color: #000 !default;
 $link-color: #0000ff !default;


### PR DESCRIPTION
This is a bug fix.

## Summary

The current $primary-color red (#ff0000) fails the WCAG requirements because it does not have sufficient contrast when used on buttons. Using slightly darker red (#b60000) does pass.

## Context

Resolves #5122.