### PR TITLE
feat: add configurability which share links to present per post #1 

### DIFF
--- a/_includes/social-share.html
+++ b/_includes/social-share.html
@@ -1,19 +1,27 @@
 <section class="page__share">
   <h4 class="page__share-title">{{ site.data.ui-text[site.locale].share_on_label | default: "Share on" }}</h4>
 
+  {% if site.share_on.x | default: true %}
   <a href="https://x.com/intent/tweet?{% if site.twitter.username %}via={{ site.twitter.username | url_encode }}&{% endif %}text={{ page.title | url_encode }}%20{{ page.url | absolute_url | url_encode }}" class="btn btn--x" aria-label="Share on X" onclick="window.open(this.href, 'window', 'left=20,top=20,width=500,height=500,toolbar=1,resizable=0'); return false;" title="{{ site.data.ui-text[site.locale].share_on_label | default: 'Share on' }} X">
     <i class="fab fa-fw fa-x-twitter" aria-hidden="true"></i><span> X</span>
   </a>
+  {% endif %}
 
+  {% if site.share_on.facebook | default: true %}
   <a href="https://www.facebook.com/sharer/sharer.php?u={{ page.url | absolute_url | url_encode }}" class="btn btn--facebook" aria-label="Share on Facebook" onclick="window.open(this.href, 'window', 'left=20,top=20,width=500,height=500,toolbar=1,resizable=0'); return false;" title="{{ site.data.ui-text[site.locale].share_on_label | default: 'Share on' }} Facebook">
     <i class="fab fa-fw fa-facebook" aria-hidden="true"></i><span> Facebook</span>
   </a>
+  {% endif %}
 
+  {% if site.share_on.linkedin | default: true %}
   <a href="https://www.linkedin.com/shareArticle?mini=true&url={{ page.url | absolute_url }}" class="btn btn--linkedin" aria-label="Share on LinkedIn" onclick="window.open(this.href, 'window', 'left=20,top=20,width=500,height=500,toolbar=1,resizable=0'); return false;" title="{{ site.data.ui-text[site.locale].share_on_label | default: 'Share on' }} LinkedIn">
     <i class="fab fa-fw fa-linkedin" aria-hidden="true"></i><span> LinkedIn</span>
   </a>
+  {% endif %}
 
+  {% if site.share_on.bluesky | default: true %}
   <a href="https://bsky.app/intent/compose?text={{ page.title | url_encode }}%20{{ page.url | absolute_url | url_encode }}" class="btn btn--bluesky" onclick="window.open(this.href, 'window', 'left=20,top=20,width=500,height=500,toolbar=1,resizable=0'); return false;" title="{{ site.data.ui-text[site.locale].share_on_label | default: 'Share on' }} Bluesky">
     <i class="fab fa-fw fa-bluesky" aria-hidden="true"></i><span> Bluesky</span>
   </a>
+  {% endif %}
 </section>


### PR DESCRIPTION
This is an enhancement or feature.

## Summary

This allows users to select (in _config.yml) via
```yaml
share_on:
  x: true
  facebook: true
  linkedin: true
  bluesky: true
```
which social share links are displayed per post.
Defaults are set to true, so that there should be no breakage for default installations.

Happy to work with your requirements and make changes as needed :)

## Context
No, I was not sure if there is an issue category for feature requests.
If this is not something you want in this project, we can still close the PR.