### PR TITLE
Fix typo which causes invalid schema to be generated

### DIFF
--- a/_includes/schema.html
+++ b/_includes/schema.html
@@ -4,7 +4,7 @@
   {% if site.social.type == "Organization" -%}
     "@type": "Organization",
     "url": {{ '/' | absolute_url | jsonify }}{% if site.og_image %},
-    "logo": {{ site_og_image | jsonify }}{% endif %}{% if site.social.links %},
+    "logo": {{ site.og_image | jsonify }}{% endif %}{% if site.social.links %},
     "sameAs": {{ site.social.links | jsonify }}{% endif %}
   {%- else -%}
     "@type": "Person",


### PR DESCRIPTION
This should be a `.` not an `_`

<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - Read the contributing document at https://github.com/mmistakes/minimal-mistakes#contributing
-->

<!--
  Choose one of the following by uncommenting it:
-->

This is a bug fix.

## Summary

The organization schema is invalid because it refers to a liquid tag that does not exist because there's a typo.

## Context

I noticed this issue while working on my site. It's very silly and incredibly minor.
