### PR TITLE
Fix typo which causes invalid schema to be generated

### DIFF
--- a/_includes/schema.html
+++ b/_includes/schema.html
@@ -4,7 +4,7 @@
   {% if site.social.type == "Organization" -%}
     "@type": "Organization",
     "url": {{ '/' | absolute_url | jsonify }}{% if site.og_image %},
-    "logo": {{ site_og_image | jsonify }}{% endif %}{% if site.social.links %},
+    "logo": {{ site.og_image | jsonify }}{% endif %}{% if site.social.links %},
     "sameAs": {{ site.social.links | jsonify }}{% endif %}
   {%- else -%}
     "@type": "Person",

--- a/_includes/schema.html
+++ b/_includes/schema.html
@@ -3,8 +3,8 @@
   "@context": "https://schema.org",
   {% if site.social.type == "Organization" -%}
     "@type": "Organization",
-    "url": {{ '/' | absolute_url | jsonify }}{% if site.og_image %},
-    "logo": {{ site.og_image | jsonify }}{% endif %}{% if site.social.links %},
+    "url": {{ '/' | absolute_url | jsonify }}{% if site_og_image %},
+    "logo": {{ site_og_image | jsonify }}{% endif %}{% if site.social.links %},
     "sameAs": {{ site.social.links | jsonify }}{% endif %}
   {%- else -%}
     "@type": "Person",


### PR DESCRIPTION
This is a bug fix.

## Summary

This should be a `_` not an `.`

The organization schema is invalid because it refers to a liquid tag that does not exist because there's a typo.

## Context

I noticed this issue while working on my site. It's very silly and incredibly minor.

Yes I know I just ended up recreating this PR, I did this via the github website instead of desktop and renaming a branch just breaks everything, but I saw in the contribution guidelines to have "nice branch names"