### PR TITLE
Preload Header Overlay Images

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -21,6 +21,10 @@
 <link rel="preload" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@latest/css/all.min.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
 <noscript><link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@latest/css/all.min.css"></noscript>
 
+{% if page.header.overlay_image %}
+  <link rel="preload" href="{{ page.header.overlay_image | relative_url }}" as="image" />
+{% endif %}
+
 {% if site.head_scripts %}
   {% for script in site.head_scripts %}
     <script src="{{ script | relative_url }}"></script>


### PR DESCRIPTION
This is an enhancement or feature.

## Summary

Header images are the most important thing outside of content. While this could also be done in the general custom header file, it's probably best the theme is practicing best practices. Be responsive for all users out of the box.

Adds a liquid check to inject a preload `<link>` tag with the overlay_image if it's specified.

## Context

If the user has overlay images in their page header liquid, make it so we by default, preload those images immediately. This will make the page look responsive and clean.
