### PR TITLE
optional `footer.since` for copyright time range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Add optional `footer.since` for copyright time range.
+
 ## [4.27.1](https://github.com/mmistakes/minimal-mistakes/releases/tag/4.27.1)
 
 ### Enhancements

--- a/_config.yml
+++ b/_config.yml
@@ -159,6 +159,7 @@ footer:
     - label: "Instagram"
       icon: "fab fa-fw fa-instagram"
       # url:
+  since: "2013"
 
 
 # Reading Files

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -18,4 +18,4 @@
   </ul>
 </div>
 
-<div class="page__footer-copyright">&copy; {{ site.time | date: '%Y' }} <a href="{{ site.copyright_url | default: site.url }}">{{ site.copyright | default: site.title }}</a>. {{ site.data.ui-text[site.locale].powered_by | default: "Powered by" }} <a href="https://jekyllrb.com" rel="nofollow">Jekyll</a> &amp; <a href="https://mademistakes.com/work/jekyll-themes/minimal-mistakes/" rel="nofollow">Minimal Mistakes</a>.</div>
+<div class="page__footer-copyright">&copy; {% assign site_time = site.time | date: '%Y' %}{% if site.footer.since and site_time != site.footer.since %}{{site.footer.since}} - {% endif %}{{ site_time }} <a href="{{ site.copyright_url | default: site.url }}">{{ site.copyright | default: site.title }}</a>. {{ site.data.ui-text[site.locale].powered_by | default: "Powered by" }} <a href="https://jekyllrb.com" rel="nofollow">Jekyll</a> &amp; <a href="https://mademistakes.com/work/jekyll-themes/minimal-mistakes/" rel="nofollow">Minimal Mistakes</a>.</div>

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -129,6 +129,7 @@ footer:
     - label: "Instagram"
       icon: "fab fa-fw fa-instagram"
       url: "https://instagram.com/mmistakes"
+  since: "2013"
 
 
 # Reading Files

--- a/docs/_docs/05-configuration.md
+++ b/docs/_docs/05-configuration.md
@@ -962,6 +962,15 @@ footer:
 
 To change "Follow:" text that precedes footer links, edit the `follow_label` key in `_data/ui-text.yml`.
 
+The copyright notice in the footer shows the year the site has been generated. This can be overridden with `time` in `_config.yml`. If `footer.since` is added and the value is not equal to the current year or the optional value of `time`, then a time range will be shown.
+
+```yaml
+footer:
+  since: "2013"
+```
+
+The above will result for example in `© 2013 - 2025 Minimal ...`. Note that `time` and `footer.since` also support values other than year numbers.
+
 ## Reading files
 
 Nothing out of the ordinary here. `include` and `exclude` may be the only things you need to alter.

--- a/test/_config.yml
+++ b/test/_config.yml
@@ -122,6 +122,7 @@ footer:
     - label: "Instagram"
       icon: "fab fa-fw fa-instagram"
       url: "https://instagram.com/"
+  since: "2013"
 
 
 # Reading Files


### PR DESCRIPTION
This is an enhancement or feature.

## Summary

This feature allows showing a time range in the copyright notice in the footer. Instead of showing only the year the website has been generated, it shows also a start year (or other time for that matter), a hyphen and the current year. E.g.

    © 2013 - 2025 Minimal ...

This feature has been tested and documented. Adding this feature will save many users customizing the header for showing a year (or other time) range in the copyright notice.

## Context

n/a