### PR TITLE
Hide page__footer-follow if there are no links nor atom feed.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Hide page__footer-follow if there are no links nor atom feed.
+
 ## [4.27.1](https://github.com/mmistakes/minimal-mistakes/releases/tag/4.27.1)
 
 ### Enhancements

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,3 +1,7 @@
+{% unless site.atom_feed.hide %}
+  {% assign show_atom = true %}
+{% endunless %}
+{% if site.footer.links or show_atom %}
 <div class="page__footer-follow">
   <ul class="social-icons">
     {% if site.data.ui-text[site.locale].follow_label %}
@@ -17,5 +21,6 @@
     {% endunless %}
   </ul>
 </div>
+{% endif %}
 
 <div class="page__footer-copyright">&copy; {{ site.time | date: '%Y' }} <a href="{{ site.copyright_url | default: site.url }}">{{ site.copyright | default: site.title }}</a>. {{ site.data.ui-text[site.locale].powered_by | default: "Powered by" }} <a href="https://jekyllrb.com" rel="nofollow">Jekyll</a> &amp; <a href="https://mademistakes.com/work/jekyll-themes/minimal-mistakes/" rel="nofollow">Minimal Mistakes</a>.</div>


### PR DESCRIPTION
This is an enhancement or feature.

## Summary

Hide page__footer-follow if there are no links nor atom feed. This prevents showing the FOLLOW label without any content next to it.

## Context

n/a