### PR TITLE
Add built-in support for jekyll-gfm-admonitions

### DIFF
--- a/_sass/minimal-mistakes/_notices.scss
+++ b/_sass/minimal-mistakes/_notices.scss
@@ -74,36 +74,42 @@
 
 /* Default notice */
 
-.notice {
+.notice,
+.markdown-alert {
   @include notice($light-gray);
 }
 
 /* Primary notice */
 
-.notice--primary {
+.notice--primary,
+.markdown-alert-important {
   @include notice($primary-color);
 }
 
 /* Info notice */
 
-.notice--info {
+.notice--info,
+.markdown-alert-note {
   @include notice($info-color);
 }
 
 /* Warning notice */
 
-.notice--warning {
+.notice--warning,
+.markdown-alert-warning {
   @include notice($warning-color);
 }
 
 /* Success notice */
 
-.notice--success {
+.notice--success,
+.markdown-alert-tip {
   @include notice($success-color);
 }
 
 /* Danger notice */
 
-.notice--danger {
+.notice--danger,
+.markdown-alert-caution {
   @include notice($danger-color);
 }


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - Read the contributing document at https://github.com/mmistakes/minimal-mistakes#contributing
-->

<!--
  Choose one of the following by uncommenting it:
-->

<!-- This is a bug fix. -->
This is an enhancement or feature.
<!-- This is a documentation change. -->

## Summary

This adds built-in support for the [`jekyll-gfm-admonitions` plugin by Helveg](https://github.com/Helveg/jekyll-gfm-admonitions/) to the Minimal Mistakes theme.  The plugin adds formatting for GFM admonitions (called ["Alerts" in GitHub](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts)) to match the styling used in notice blocks.
