### PR TITLE
Add IndieWeb microformat support and configurable footer rel attribute

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -144,6 +144,7 @@ footer:
     - label: "Twitter"
       icon: "fab fa-fw fa-twitter-square"
       # url:
+      # rel: "me"  # optional: adds rel attribute (e.g. for IndieWeb web sign-in)
     - label: "Facebook"
       icon: "fab fa-fw fa-facebook-square"
       # url:

--- a/_includes/archive-single.html
+++ b/_includes/archive-single.html
@@ -17,14 +17,14 @@
         <img src="{{ teaser | relative_url }}" alt="">
       </div>
     {% endif %}
-    <h2 class="archive__item-title no_toc" itemprop="headline">
+    <h2 class="archive__item-title no_toc p-name" itemprop="headline">
       {% if post.link %}
-        <a href="{{ post.link }}">{{ title }}</a> <a href="{{ post.url | relative_url }}" rel="permalink"><i class="fas fa-link" aria-hidden="true" title="permalink"></i><span class="sr-only">Permalink</span></a>
+        <a href="{{ post.link }}">{{ title }}</a> <a class="u-url" href="{{ post.url | relative_url }}" rel="permalink"><i class="fas fa-link" aria-hidden="true" title="permalink"></i><span class="sr-only">Permalink</span></a>
       {% else %}
-        <a href="{{ post.url | relative_url }}" rel="permalink">{{ title }}</a>
+        <a class="u-url" href="{{ post.url | relative_url }}" rel="permalink">{{ title }}</a>
       {% endif %}
     </h2>
     {% include page__meta.html type=include.type %}
-    {% if post.excerpt %}<p class="archive__item-excerpt" itemprop="description">{{ post.excerpt | markdownify | strip_html | truncate: 160 }}</p>{% endif %}
+    {% if post.excerpt %}<p class="archive__item-excerpt p-summary" itemprop="description">{{ post.excerpt | markdownify | strip_html | truncate: 160 }}</p>{% endif %}
   </article>
 </div>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -11,13 +11,13 @@
     {% if site.footer.links %}
       {% for link in site.footer.links %}
         {% if link.label and link.url %}
-          <li><a href="{{ link.url }}" rel="nofollow noopener noreferrer"><i class="{{ link.icon | default: 'fas fa-link' }}" aria-hidden="true"></i> {{ link.label | escape_once | strip }}</a></li>
+          <li><a href="{{ link.url }}" rel="nofollow noopener noreferrer{% if link.rel %} {{ link.rel }}{% endif %}"><i class="{{ link.icon | default: 'fas fa-link' }}" aria-hidden="true"></i> {{ link.label | escape_once | strip }}</a></li>
         {% endif %}
       {% endfor %}
     {% endif %}
 
     {% unless site.atom_feed.hide %}
-      <li><a href="{% if site.atom_feed.path %}{{ site.atom_feed.path }}{% else %}{{ '/feed.xml' | relative_url }}{% endif %}"><i class="fas fa-fw fa-rss-square" aria-hidden="true"></i> {{ site.data.ui-text[site.locale].feed_label | default: "Feed" }}</a></li>
+      <li><a href="{% if site.atom_feed.path %}{{ site.atom_feed.path }}{% else %}{{ '/feed.xml' | relative_url }}{% endif %}"><i class="fas fa-fw fa-square-rss" aria-hidden="true"></i> {{ site.data.ui-text[site.locale].feed_label | default: "Feed" }}</a></li>
     {% endunless %}
   </ul>
 </div>

--- a/_includes/page__date.html
+++ b/_includes/page__date.html
@@ -1,6 +1,6 @@
 {% assign date_format = site.date_format | default: "%B %-d, %Y" %}
 {% if page.last_modified_at %}
-  <p class="page__date"><strong><i class="fas fa-fw fa-calendar-alt" aria-hidden="true"></i> {{ site.data.ui-text[site.locale].date_label | default: "Updated:" }}</strong> <time class="dt-published" datetime="{{ page.last_modified_at | date: "%Y-%m-%d" }}">{{ page.last_modified_at | date: date_format }}</time></p>
+  <p class="page__date"><strong><i class="fas fa-fw fa-calendar-alt" aria-hidden="true"></i> {{ site.data.ui-text[site.locale].date_label | default: "Updated:" }}</strong> <time class="dt-updated" datetime="{{ page.last_modified_at | date: "%Y-%m-%d" }}">{{ page.last_modified_at | date: date_format }}</time></p>
 {% elsif page.date %}
   <p class="page__date"><strong><i class="fas fa-fw fa-calendar-alt" aria-hidden="true"></i> {{ site.data.ui-text[site.locale].date_label | default: "Updated:" }}</strong> <time class="dt-published" datetime="{{ page.date | date_to_xmlschema }}">{{ page.date | date: date_format }}</time></p>
 {% endif %}

--- a/_layouts/single.html
+++ b/_layouts/single.html
@@ -21,7 +21,7 @@ layout: default
 <div id="main" role="main">
   {% include sidebar.html %}
 
-  <article class="page" itemscope itemtype="https://schema.org/CreativeWork"{% if page.locale %} lang="{{ page.locale }}"{% endif %}>
+  <article class="page h-entry" itemscope itemtype="https://schema.org/CreativeWork"{% if page.locale %} lang="{{ page.locale }}"{% endif %}>
     {% if page.title %}<meta itemprop="headline" content="{{ page.title | replace: '|', '&#124;' | markdownify | strip_html | strip_newlines | escape_once }}">{% endif %}
     {% if page.excerpt %}<meta itemprop="description" content="{{ page.excerpt | markdownify | strip_html | strip_newlines | escape_once }}">{% endif %}
     {% if page.date %}<meta itemprop="datePublished" content="{{ page.date | date_to_xmlschema }}">{% endif %}
@@ -31,7 +31,7 @@ layout: default
       {% unless page.header.overlay_color or page.header.overlay_image %}
         <header>
           {% if page.title -%}
-          <h1 id="page-title" class="page__title" itemprop="headline">
+          <h1 id="page-title" class="page__title p-name" itemprop="headline">
             <a href="{{ page.url | absolute_url }}" itemprop="url">{{ page.title | markdownify | remove: "<p>" | remove: "</p>" }}</a>
           </h1>
           {%- endif %}
@@ -39,7 +39,7 @@ layout: default
         </header>
       {% endunless %}
 
-      <section class="page__content" itemprop="text">
+      <section class="page__content e-content" itemprop="text">
         {% if page.toc %}
           <aside class="sidebar__right {% if page.toc_sticky %}sticky{% endif %}">
             <nav class="toc">

--- a/docs/_docs/05-configuration.md
+++ b/docs/_docs/05-configuration.md
@@ -947,11 +947,12 @@ To customize the author sidebar, read the full [layout documentation]({{ "/docs/
 
 Footer links can be added under the `footer.links` array.
 
-| Name      | Description                                                                                           |
-| --------- | ----------------------------------------------------------------------------------------------------- |
-| **label** | Link label (e.g. `"Twitter"`)                                                                         |
-| **icon**  | [Font Awesome icon](https://fontawesome.com/v6/search) classes (e.g. `"fab fa-fw fa-twitter-square"`) |
-| **url**   | Link URL (e.g. `"https://twitter.com/mmistakes"`)                                                     |
+| Name      | Description                                                                                                                                                   |
+| --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **label** | Link label (e.g. `"Twitter"`)                                                                                                                                 |
+| **icon**  | [Font Awesome icon](https://fontawesome.com/v6/search) classes (e.g. `"fab fa-fw fa-twitter-square"`)                                                         |
+| **url**   | Link URL (e.g. `"https://twitter.com/mmistakes"`)                                                                                                             |
+| **rel**   | Optional [link relation](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel) appended to the default `nofollow noopener noreferrer` (e.g. `"me"` for [IndieWeb web sign-in](https://indieweb.org/How_to_set_up_web_sign-in_on_your_own_domain)) |
 
 ```yaml
 footer:
@@ -962,6 +963,7 @@ footer:
     - label: "GitHub"
       icon: "fab fa-fw fa-github"
       url: "https://github.com/mmistakes"
+      rel: "me"
     - label: "Instagram"
       icon: "fab fa-fw fa-instagram"
       url: "https://instagram.com/mmistakes"


### PR DESCRIPTION
Refs #5030, #4114

This PR adds [microformats2](http://microformats.org/wiki/h-entry) markup
and a configurable `rel` attribute on footer links to improve IndieWeb
compatibility.

### Microformat classes

| File | Classes added | Purpose |
|------|--------------|---------|
| `_layouts/single.html` | `h-entry`, `p-name`, `e-content` | Marks posts as parseable entries for feed readers and webmention services |
| `_includes/archive-single.html` | `p-name`, `u-url`, `p-summary` | Marks archive listings for feed discovery |
| `_includes/page__date.html` | `dt-updated` (was `dt-published`) | Correctly distinguishes modification date from publication date |

These are CSS class additions only — no visual or behavioral change.
The existing Schema.org `itemprop` markup is preserved alongside the
microformat classes.

### Configurable `rel` on footer links

`_includes/footer.html` now supports an optional `rel` key on each
footer link in `_config.yml`:

```yaml
footer:
  links:
    - label: "GitHub"
      icon: "fab fa-fw fa-github"
      url: "https://github.com/username"
      rel: "me"
```

This enables [`rel="me"` web sign-in](https://indieweb.org/How_to_set_up_web_sign-in_on_your_own_domain)
from the homepage on a per-link basis. The value is appended to the
existing `nofollow noopener noreferrer`, so the rendered output becomes
`rel="nofollow noopener noreferrer me"`.

### Relationship to #5030 and #4114

This PR implements the non-controversial subset of #5030:

- Microformat classes (`h-entry`, `p-name`, `e-content`, `u-url`, `p-summary`)
- `dt-updated` fix for `last_modified_at`
- Configurable `rel` on footer links (fixes the `item.rel` / `link.rel` bug in #5030)

It does **not** change the existing `rel="me"` on author profile links.
That change (proposed in #5030 as a blanket swap to `rel="author"`) would
break web sign-in for users whose homepage includes the author sidebar.
IndieAuth validators only check the homepage, so the current `rel="me"`
on sidebar links is harmless on post pages and functional on the homepage.
The `rel="me"` vs `rel="author"` question is better resolved in the
discussion on #5030.

#4114 proposed adding `rel="me"` unconditionally to all footer links.
@iBug [commented](https://github.com/mmistakes/minimal-mistakes/pull/4114#issuecomment-2071473220)
that a per-link option would be better. This PR implements that approach.