### PR TITLE
Add fediverse:creator meta tag for link preview attribution

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -119,6 +119,7 @@ author:
   bio              : "I am an **amazing** person."
   location         : "Somewhere"
   email            :
+  # fediverse      : "@you@instance.social"  # used for fediverse:creator meta tag
   links:
     - label: "Email"
       icon: "fas fa-fw fa-envelope-square"

--- a/_includes/seo.html
+++ b/_includes/seo.html
@@ -96,6 +96,10 @@
   {% endif %}
 {% endif %}
 
+{% if author.fediverse %}
+  <meta name="fediverse:creator" content="{{ author.fediverse }}">
+{% endif %}
+
 {% if page.date %}
   <meta property="article:published_time" content="{{ page.date | date_to_xmlschema }}">
 {% endif %}

--- a/docs/_docs/05-configuration.md
+++ b/docs/_docs/05-configuration.md
@@ -798,6 +798,18 @@ And if I assign `@mmistakes` as an author account it will appear in the Twitter 
 **Note**: You need to validate cards are working and have Twitter [approve Player Cards](https://developer.twitter.com/en/docs/tweets/optimize-with-cards/overview/player-card) before they begin showing up.
 {: .notice--warning}
 
+##### Fediverse creator
+
+If the site author (or a per-page author override) has a `fediverse` value set, a `<meta name="fediverse:creator">` tag is emitted. This enables "by @user@instance" attribution on Mastodon, Pixelfed, Flipboard, and other fediverse platforms — the same role `twitter:creator` plays for Twitter Cards.
+
+The value is set in the `author` block of `_config.yml` (or in `_data/authors.yml` for multi-author sites):
+
+```yaml
+author:
+  name: "Your Name"
+  fediverse: "@you@instance.social"
+```
+
 ##### Facebook Open Graph
 
 If you have a Facebook ID or publisher page add them:
@@ -916,6 +928,7 @@ author:
   avatar   : "/assets/images/bio-photo.jpg"
   bio      : "My awesome biography constrained to a sentence or two goes here."
   location : "Somewhere, USA"
+  fediverse: "@you@instance.social"
 ```
 
 Author links are all optional, include the ones you want visible under the `author.links` array.

--- a/docs/_docs/09-authors.md
+++ b/docs/_docs/09-authors.md
@@ -18,6 +18,7 @@ Billy Rick:
   name        : "Billy Rick"
   bio         : "What do you want, jewels? I am a very extravagant man."
   avatar      : "/assets/images/bio-photo-2.jpg"
+  fediverse   : "@billyrick@instance.social"
   links:
     - label: "Email"
       icon: "fas fa-fw fa-envelope-square"


### PR DESCRIPTION
Add `<meta name="fediverse:creator">` support, enabling "by @user@instance" attribution on Mastodon 4.3+, Pixelfed, Flipboard, and other fediverse platforms. This is the fediverse equivalent of the existing `twitter:creator` meta tag.

### How it works

When `author.fediverse` is set, the theme emits a single meta tag:

```html
<meta name="fediverse:creator" content="@you@instance.social">
```

The value is read from the resolved author object in `seo.html`, so it works with both `site.author` in `_config.yml` and per-page overrides via `_data/authors.yml` — the same resolution path used for `twitter:creator`.

The consuming platform uses [WebFinger](https://webfinger.net/) to look up the address at display time, so the tag is protocol-agnostic and does not need to know whether the account is Mastodon, Pixelfed, or anything else.

If no `fediverse` value is configured, no tag is emitted — existing behavior is unchanged.

### Configuration

In `_config.yml`:
```yaml
author:
  name: "Your Name"
  fediverse: "@you@instance.social"
```

Per-author override in `_data/authors.yml`:
```yaml
Billy Rick:
  name: "Billy Rick"
  fediverse: "@billyrick@instance.social"
```

### References

- [Highlighting journalism on Mastodon](https://blog.joinmastodon.org/2024/07/highlighting-journalism-on-mastodon/) — blog post introducing the `fediverse:creator` tag
- [Mastodon microformats spec](https://docs.joinmastodon.org/spec/microformats/#fediverse-creator) — technical documentation