### PR TITLE
Update hardcoded icon classes for Font Awesome 6

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -121,16 +121,16 @@ author:
   email            :
   links:
     - label: "Email"
-      icon: "fas fa-fw fa-envelope-square"
+      icon: "fas fa-fw fa-square-envelope"
       # url: "mailto:your.name@email.com"
     - label: "Website"
       icon: "fas fa-fw fa-link"
       # url: "https://your-website.com"
     - label: "Twitter"
-      icon: "fab fa-fw fa-twitter-square"
+      icon: "fab fa-fw fa-square-x-twitter"
       # url: "https://twitter.com/"
     - label: "Facebook"
-      icon: "fab fa-fw fa-facebook-square"
+      icon: "fab fa-fw fa-square-facebook"
       # url: "https://facebook.com/"
     - label: "GitHub"
       icon: "fab fa-fw fa-github"
@@ -143,11 +143,11 @@ author:
 footer:
   links:
     - label: "Twitter"
-      icon: "fab fa-fw fa-twitter-square"
+      icon: "fab fa-fw fa-square-x-twitter"
       # url:
       # rel: "me"  # optional: adds rel attribute (e.g. for IndieWeb web sign-in)
     - label: "Facebook"
-      icon: "fab fa-fw fa-facebook-square"
+      icon: "fab fa-fw fa-square-facebook"
       # url:
     - label: "GitHub"
       icon: "fab fa-fw fa-github"

--- a/_includes/author-profile.html
+++ b/_includes/author-profile.html
@@ -28,7 +28,7 @@
     <ul class="author__urls social-icons">
       {% if author.location %}
         <li itemprop="homeLocation" itemscope itemtype="https://schema.org/Place">
-          <i class="fas fa-fw fa-map-marker-alt" aria-hidden="true"></i> <span itemprop="name" class="p-locality">{{ author.location }}</span>
+          <i class="fas fa-fw fa-location-dot" aria-hidden="true"></i> <span itemprop="name" class="p-locality">{{ author.location }}</span>
         </li>
       {% endif %}
 
@@ -52,7 +52,7 @@
         <li>
           <a href="mailto:{{ author.email }}" rel="me" class="u-email">
             <meta itemprop="email" content="{{ author.email }}" />
-            <i class="fas fa-fw fa-envelope-square" aria-hidden="true"></i><span class="label">{{ site.data.ui-text[locale].email_label | default: "Email" }}</span>
+            <i class="fas fa-fw fa-square-envelope" aria-hidden="true"></i><span class="label">{{ site.data.ui-text[locale].email_label | default: "Email" }}</span>
           </a>
         </li>
       {% endif %}
@@ -68,7 +68,7 @@
       {% if author.twitter %}
         <li>
           <a href="https://twitter.com/{{ author.twitter }}" itemprop="sameAs" rel="nofollow noopener noreferrer me">
-            <i class="fab fa-fw fa-twitter-square" aria-hidden="true"></i><span class="label">Twitter</span>
+            <i class="fab fa-fw fa-square-x-twitter" aria-hidden="true"></i><span class="label">Twitter</span>
           </a>
         </li>
       {% endif %}
@@ -76,7 +76,7 @@
       {% if author.facebook %}
         <li>
           <a href="https://www.facebook.com/{{ author.facebook }}" itemprop="sameAs" rel="nofollow noopener noreferrer me">
-            <i class="fab fa-fw fa-facebook-square" aria-hidden="true"></i><span class="label">Facebook</span>
+            <i class="fab fa-fw fa-square-facebook" aria-hidden="true"></i><span class="label">Facebook</span>
           </a>
         </li>
       {% endif %}
@@ -92,7 +92,7 @@
       {% if author.xing %}
         <li>
           <a href="https://www.xing.com/profile/{{ author.xing }}" itemprop="sameAs" rel="nofollow noopener noreferrer me">
-            <i class="fab fa-fw fa-xing-square" aria-hidden="true"></i><span class="label">XING</span>
+            <i class="fab fa-fw fa-square-xing" aria-hidden="true"></i><span class="label">XING</span>
           </a>
         </li>
       {% endif %}
@@ -108,7 +108,7 @@
       {% if author.tumblr %}
         <li>
           <a href="https://{{ author.tumblr }}.tumblr.com" itemprop="sameAs" rel="nofollow noopener noreferrer me">
-            <i class="fab fa-fw fa-tumblr-square" aria-hidden="true"></i><span class="label">Tumblr</span>
+            <i class="fab fa-fw fa-square-tumblr" aria-hidden="true"></i><span class="label">Tumblr</span>
           </a>
         </li>
       {% endif %}
@@ -148,7 +148,7 @@
       {% if author.lastfm %}
         <li>
           <a href="https://last.fm/user/{{ author.lastfm }}" itemprop="sameAs" rel="nofollow noopener noreferrer me">
-            <i class="fab fa-fw fa-lastfm-square" aria-hidden="true"></i><span class="label">Last.fm</span>
+            <i class="fab fa-fw fa-square-lastfm" aria-hidden="true"></i><span class="label">Last.fm</span>
           </a>
         </li>
       {% endif %}

--- a/docs/_docs/05-configuration.md
+++ b/docs/_docs/05-configuration.md
@@ -923,7 +923,7 @@ Author links are all optional, include the ones you want visible under the `auth
 | Name      | Description                                                                                           |
 | --------- | ----------------------------------------------------------------------------------------------------- |
 | **label** | Link label (e.g. `"Twitter"`)                                                                         |
-| **icon**  | [Font Awesome icon](https://fontawesome.com/v6/search) classes (e.g. `"fab fa-fw fa-twitter-square"`) |
+| **icon**  | [Font Awesome icon](https://fontawesome.com/v6/search) classes (e.g. `"fab fa-fw fa-square-x-twitter"`) |
 | **url**   | Link URL (e.g. `"https://twitter.com/mmistakes"`)                                                     |
 
 ```yaml
@@ -937,7 +937,7 @@ author:
       icon: "fas fa-fw fa-link"
       url: "https://mademistakes.com"
     - label: "Twitter"
-      icon: "fab fa-fw fa-twitter-square"
+      icon: "fab fa-fw fa-square-x-twitter"
       url: "https://twitter.com/mmistakes"
     - label: "GitHub"
       icon: "fab fa-fw fa-github"
@@ -956,7 +956,7 @@ Footer links can be added under the `footer.links` array.
 | Name      | Description                                                                                                                                                   |
 | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **label** | Link label (e.g. `"Twitter"`)                                                                                                                                 |
-| **icon**  | [Font Awesome icon](https://fontawesome.com/v6/search) classes (e.g. `"fab fa-fw fa-twitter-square"`)                                                         |
+| **icon**  | [Font Awesome icon](https://fontawesome.com/v6/search) classes (e.g. `"fab fa-fw fa-square-x-twitter"`)                                                         |
 | **url**   | Link URL (e.g. `"https://twitter.com/mmistakes"`)                                                                                                             |
 | **rel**   | Optional [link relation](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel) appended to the default `nofollow noopener noreferrer` (e.g. `"me"` for [IndieWeb web sign-in](https://indieweb.org/How_to_set_up_web_sign-in_on_your_own_domain)) |
 
@@ -964,7 +964,7 @@ Footer links can be added under the `footer.links` array.
 footer:
   links:
     - label: "Twitter"
-      icon: "fab fa-fw fa-twitter-square"
+      icon: "fab fa-fw fa-square-x-twitter"
       url: "https://twitter.com/mmistakes"
     - label: "GitHub"
       icon: "fab fa-fw fa-github"

--- a/docs/_docs/09-authors.md
+++ b/docs/_docs/09-authors.md
@@ -20,13 +20,13 @@ Billy Rick:
   avatar      : "/assets/images/bio-photo-2.jpg"
   links:
     - label: "Email"
-      icon: "fas fa-fw fa-envelope-square"
+      icon: "fas fa-fw fa-square-envelope"
       url: "mailto:billyrick@rick.com"
     - label: "Website"
       icon: "fas fa-fw fa-link"
       url: "https://thewhip.com"
     - label: "Twitter"
-      icon: "fab fa-fw fa-twitter-square"
+      icon: "fab fa-fw fa-square-x-twitter"
       url: "https://twitter.com/extravagantman"
 
 Cornelius Fiddlebone:
@@ -35,10 +35,10 @@ Cornelius Fiddlebone:
   avatar      : "/assets/images/bio-photo.jpg"
   links:
     - label: "Email"
-      icon: "fas fa-fw fa-envelope-square"
+      icon: "fas fa-fw fa-square-envelope"
       url: "mailto:cornelius@thewhip.com"
     - label: "Twitter"
-      icon: "fab fa-fw fa-twitter-square"
+      icon: "fab fa-fw fa-square-x-twitter"
       url: "https://twitter.com/rhymeswithsackit"
 ```
 

--- a/docs/_docs/10-layouts.md
+++ b/docs/_docs/10-layouts.md
@@ -607,7 +607,7 @@ author:
       icon: "fas fa-fw fa-link"
       url: "https://mademistakes.com"
     - label: "Twitter"
-      icon: "fab fa-fw fa-twitter-square"
+      icon: "fab fa-fw fa-square-x-twitter"
       url: "https://twitter.com/mmistakes"
     - label: "GitHub"
       icon: "fab fa-fw fa-github"

--- a/docs/_posts/2012-03-15-layout-author-override.md
+++ b/docs/_posts/2012-03-15-layout-author-override.md
@@ -20,13 +20,13 @@ Billy Rick:
   avatar      : "/assets/images/bio-photo-2.jpg"
   links:
     - label: "Email"
-      icon: "fas fa-fw fa-envelope-square"
+      icon: "fas fa-fw fa-square-envelope"
       url: "mailto:billyrick@rick.com"
     - label: "Website"
       icon: "fas fa-fw fa-link"
       url: "https://thewhip.com"
     - label: "Twitter"
-      icon: "fab fa-fw fa-twitter-square"
+      icon: "fab fa-fw fa-square-x-twitter"
       url: "https://twitter.com/extravagantman"
 
 Cornelius Fiddlebone:
@@ -35,10 +35,10 @@ Cornelius Fiddlebone:
   avatar      : "/assets/images/bio-photo.jpg"
   links:
     - label: "Email"
-      icon: "fas fa-fw fa-envelope-square"
+      icon: "fas fa-fw fa-square-envelope"
       url: "mailto:cornelius@thewhip.com"
     - label: "Twitter"
-      icon: "fab fa-fw fa-twitter-square"
+      icon: "fab fa-fw fa-square-x-twitter"
       url: "https://twitter.com/rhymeswithsackit"
 ```
 


### PR DESCRIPTION
The theme loads Font Awesome 6 from CDN but several hardcoded icon
class names in templates and documentation still use the FA5 naming
convention, relying on backward-compatibility aliases.

This updates all hardcoded icon references to native FA6 names:

| FA5 name | FA6 name |
|----------|----------|
| `fa-envelope-square` | `fa-square-envelope` |
| `fa-twitter-square` | `fa-square-x-twitter` |
| `fa-facebook-square` | `fa-square-facebook` |
| `fa-xing-square` | `fa-square-xing` |
| `fa-tumblr-square` | `fa-square-tumblr` |
| `fa-lastfm-square` | `fa-square-lastfm` |
| `fa-map-marker-alt` | `fa-location-dot` |

Files changed: `_includes/author-profile.html`, `_config.yml`, and
documentation examples in `05-configuration.md`, `09-authors.md`,
`10-layouts.md`, and the author override example post.

No visual change — FA6's backward-compat aliases still work, but
using the canonical names avoids depending on aliases that may be
removed in a future FA release.