### PR TITLE
Add custom sidebar content hook

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -16,5 +16,6 @@
       {% include nav_list locale=locale nav=page.sidebar.nav %}
     {% endif %}
   {% endif %}
+  {% include sidebar-custom.html %}
   </div>
 {% endif %}

--- a/docs/_docs/10-layouts.md
+++ b/docs/_docs/10-layouts.md
@@ -663,6 +663,8 @@ sidebar:
 **Note:** Custom sidebar content added to a post or page's YAML Front Matter will appear below the author profile if enabled with `author_profile: true`.
 {: .notice--info}
 
+For more advanced customization, create `_includes/sidebar-custom.html` in your site. Its contents are included at the bottom of the sidebar on every page, after the author profile, YAML-defined blocks, and navigation menu. This follows the same pattern as [`head/custom.html`](#custom-head-tags) and `author-profile-custom-links.html`.
+
 ### Custom sidebar navigation menu
 
 To create a sidebar menu[^sidebar-menu] similar to the one found in the theme's documentation pages you'll need to modify a `_data` file and some YAML Front Matter.


### PR DESCRIPTION
Add `{% include sidebar-custom.html %}` before the closing `</div>`
in `sidebar.html`, with an empty `sidebar-custom.html` extension
point. This follows the existing pattern of `head/custom.html` and
`author-profile-custom-links.html`, letting users inject arbitrary
HTML into the sidebar without overriding the entire `sidebar.html`
file.

The include renders at the bottom of the sidebar, after the author
profile, YAML-defined sidebar blocks, and navigation menu. The
empty default file ensures existing sites are unaffected.

Documentation updated in the "Custom sidebar content" section of
the layouts docs.