### PR TITLE
Add config toggle to suppress taxonomy display on posts

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -293,6 +293,7 @@ category_archive:
 tag_archive:
   type: liquid
   path: /tags/
+# show_taxonomy: false  # set to false to hide tag/category lists on posts
 # https://github.com/jekyll/jekyll-archives
 # jekyll-archives:
 #   enabled:

--- a/_includes/page__taxonomy.html
+++ b/_includes/page__taxonomy.html
@@ -1,8 +1,10 @@
 {% assign locale = include.locale | default: site.locale %}
-{% if site.tag_archive.type and page.tags[0] %}
-  {% include tag-list.html locale=locale %}
-{% endif %}
+{% unless site.show_taxonomy == false %}
+  {% if site.tag_archive.type and page.tags[0] %}
+    {% include tag-list.html locale=locale %}
+  {% endif %}
 
-{% if site.category_archive.type and page.categories[0] %}
-  {% include category-list.html locale=locale %}
-{% endif %}
+  {% if site.category_archive.type and page.categories[0] %}
+    {% include category-list.html locale=locale %}
+  {% endif %}
+{% endunless %}

--- a/docs/_docs/05-configuration.md
+++ b/docs/_docs/05-configuration.md
@@ -1188,6 +1188,12 @@ tag_archive:
   path: /tags/
 ```
 
+To hide the tag and category lists displayed on each post, set `show_taxonomy: false` in `_config.yml`. The taxonomy archive pages themselves are unaffected — only the per-post lists are suppressed.
+
+```yaml
+show_taxonomy: false
+```
+
 Which would create category and tag links in the breadcrumbs and page meta like: `/categories/#foo` and `/tags/#foo`.
 
 **Note:** these are simply hash (fragment) links into the full taxonomy index pages. For them to resolve properly, the category and tag index pages need to exist at [`/categories/index.html`](https://github.com/{{ site.repository }}/blob/master/docs/_pages/category-archive.md) (copy to `_pages/category-archive.md`) and [`/tags/index.html`](https://github.com/{{ site.repository }}/blob/master/docs/_pages/tag-archive.md) (copy to `_pages/tag-archive.md`).


### PR DESCRIPTION
Add a `show_taxonomy` site config option. When set to `false`, the
per-post tag and category lists rendered by `page__taxonomy.html`
are suppressed. Default behavior is unchanged — the lists display
unless explicitly disabled.

### Configuration

```yaml
show_taxonomy: false
```

This only affects the inline tag/category lists on individual posts.
Taxonomy archive pages, breadcrumb links, and page meta are
unaffected.

### Use case

Some sites use tags and categories for internal organization (e.g.
driving archive pages or filtering) but don't want them displayed
on each post. Currently the only way to suppress them is to
override the entire `page__taxonomy.html` include with an empty
file. This provides a cleaner, config-driven alternative.

Documentation updated in the taxonomy archive section of the
configuration docs.