### PR TITLE
Respect custom parameters in yiq-contrast-color function

### DIFF
--- a/_sass/minimal-mistakes/_mixins.scss
+++ b/_sass/minimal-mistakes/_mixins.scss
@@ -78,7 +78,7 @@
   $light: $yiq-contrasted-light-default,
   $threshold: $yiq-contrasted-threshold
 ) {
-  @return if(yiq-is-light($color, $threshold), $yiq-contrasted-dark-default, $yiq-contrasted-light-default);
+  @return if(yiq-is-light($color, $threshold), $dark, $light);
 }
 
 @mixin yiq-contrasted(


### PR DESCRIPTION
This is a bug fix.

## Summary

The yiq-contrast-color function ignored its $dark and $light parameters and always returned global default variables instead.

This change ensures the function correctly uses the provided arguments, while still falling back to default values when not specified.
