### PR TITLE
Allow specifying `rtl` in both page and layout

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -16,7 +16,7 @@ minimal_mistakes_skin    : "default" # "air", "aqua", "contrast", "dark", "dirt"
 
 # Site Settings
 locale                   : "en-US"
-rtl                      : # true, false (default) # turns direction of the page into right to left for RTL languages
+direction                : # "ltr" (default), "rtl" # set the direction of the page
 title                    : "Site Title"
 title_separator          : "-"
 subtitle                 : # site tagline that appears below site title in masthead

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -4,13 +4,13 @@
 
 <!doctype html>
 {% include copyright.html %}
-<html lang="{{ locale | replace: '_', '-' | default: 'en' }}" class="no-js">
+<html lang="{{ locale | replace: '_', '-' | default: 'en' }}" class="no-js" dir="{{ page.direction | default: layout.direction | default: site.direction | default: 'ltr' }}">
   <head>
     {% include head.html locale=locale %}
     {% include head/custom.html %}
   </head>
 
-  <body class="layout--{{ page.layout | default: layout.layout }}{% if page.classes or layout.classes %}{{ page.classes | default: layout.classes | join: ' ' | prepend: ' ' }}{% endif %}" dir="{{ page.direction | default: layout.direction | default: site.direction | default: 'ltr' }}">
+  <body class="layout--{{ page.layout | default: layout.layout }}{% if page.classes or layout.classes %}{{ page.classes | default: layout.classes | join: ' ' | prepend: ' ' }}{% endif %}">
     {% include_cached skip-links.html locale=locale %}
     {% include_cached masthead.html locale=locale %}
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -4,13 +4,13 @@
 
 <!doctype html>
 {% include copyright.html %}
-<html lang="{{ locale | replace: "_", "-" | default: "en" }}" class="no-js">
+<html lang="{{ locale | replace: '_', '-' | default: 'en' }}" class="no-js">
   <head>
     {% include head.html locale=locale %}
     {% include head/custom.html %}
   </head>
 
-  <body class="layout--{{ page.layout | default: layout.layout }}{% if page.classes or layout.classes %}{{ page.classes | default: layout.classes | join: ' ' | prepend: ' ' }}{% endif %}" dir="{% if page.rtl | default: layout.rtl | default: site.rtl %}rtl{% else %}ltr{% endif %}">
+  <body class="layout--{{ page.layout | default: layout.layout }}{% if page.classes or layout.classes %}{{ page.classes | default: layout.classes | join: ' ' | prepend: ' ' }}{% endif %}" dir="{{ page.direction | default: layout.direction | default: site.direction | default: 'ltr' }}">
     {% include_cached skip-links.html locale=locale %}
     {% include_cached masthead.html locale=locale %}
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -10,7 +10,7 @@
     {% include head/custom.html %}
   </head>
 
-  <body class="layout--{{ page.layout | default: layout.layout }}{% if page.classes or layout.classes %}{{ page.classes | default: layout.classes | join: ' ' | prepend: ' ' }}{% endif %}" dir="{% if site.rtl %}rtl{% else %}ltr{% endif %}">
+  <body class="layout--{{ page.layout | default: layout.layout }}{% if page.classes or layout.classes %}{{ page.classes | default: layout.classes | join: ' ' | prepend: ' ' }}{% endif %}" dir="{% if page.rtl | default: layout.rtl | default: site.rtl %}rtl{% else %}ltr{% endif %}">
     {% include_cached skip-links.html locale=locale %}
     {% include_cached masthead.html locale=locale %}
 

--- a/docs/_docs/05-configuration.md
+++ b/docs/_docs/05-configuration.md
@@ -218,11 +218,11 @@ By default your site title is used in the masthead. You can override this text b
 masthead_title: "My Custom Title"
 ```
 
-### Site RTL direction
+### Site direction
 
-`site.rtl` is used to turn the direction of the page into right to left. This option can be used for RTL languages (like Arabic, Persian, etc)
+`site.direction` is used to sets the direction of the page. This option can be used for RTL languages (like Arabic, Persian, etc)
 
-_Example:_ `rtl: true` sets the direction of the page to right to left. By default this option is `rtl: false`.
+_Example:_ `direction: rtl` sets the direction of the page to right to left. By default this option is `direction: ltr`.
 
 ### Breadcrumb navigation (beta)
 


### PR DESCRIPTION
This is an enhancement or feature.

## Summary

Allow specifying `rtl` in both page and layout.

```markdown
---
title: xxx
locale: ar
direction: rtl
---

xxx
```

Move the `dir` attribute from the `body` to the `html`.

https://github.com/mmistakes/minimal-mistakes/blob/5786c35342d4f359ca40479f38e6255785ab1591/assets/js/_main.js#L155
