### PR TITLE
Add title attribute to video iframes for accessibility

### DIFF
--- a/_includes/video
+++ b/_includes/video
@@ -16,9 +16,29 @@
 {% endcapture %}
 {% assign video_src = video_src | strip %}
 
+{% capture video_title %}
+  {% if include.title %}
+    {{ include.title }}
+  {% else %}
+    {% case video_provider %}
+    {% when "vimeo" %}
+      Vimeo video player
+    {% when "youtube" %}
+      YouTube video player
+    {% when "google-drive" %}
+      Google Drive video player
+    {% when "bilibili" %}
+      Bilibili video player
+    {% else %}
+      Video player
+    {% endcase %}
+  {% endif %}
+{% endcapture %}
+{% assign video_title = video_title | strip %}
+
 <!-- Courtesy of embedresponsively.com -->
 {% unless video_src == "" %}
   <div class="responsive-video-container">
-    <iframe src="{{ video_src }}" frameborder="0" webkitAllowFullScreen mozallowfullscreen allowfullscreen></iframe>
+    <iframe src="{{ video_src }}" title="{{ video_title }}" frameborder="0" webkitAllowFullScreen mozallowfullscreen allowfullscreen></iframe>
   </div>
 {% endunless %}


### PR DESCRIPTION
## Summary

- The `_includes/video` template generates `<iframe>` elements without a `title` attribute, which fails the Lighthouse accessibility audit rule "`<iframe>` elements do not have a title"
- Adds a `title` attribute to the iframe, with support for an optional `title` parameter on the include
- Falls back to a provider-based default (e.g. "YouTube video player", "Vimeo video player") when no explicit title is given

## Details

The [WCAG Success Criterion 4.1.2](https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html) requires that all user interface components have an accessible name. For `<iframe>` elements, a `title` attribute serves this purpose and is what Lighthouse checks for.

### Usage

Existing includes continue to work without changes and get a default title:

```liquid
{% include video id="dQw4w9WgXcQ" provider="youtube" %}
<!-- renders with title="YouTube video player" -->
```

A custom title can be provided for better accessibility:

```liquid
{% include video id="dQw4w9WgXcQ" provider="youtube" title="Rick Astley - Never Gonna Give You Up" %}
```

Related: #1913