### PR TITLE
Update sudo-bot/action-pull-request-lock to v2

### DIFF
--- a/.github/workflows/bad-pr.yml
+++ b/.github/workflows/bad-pr.yml
@@ -27,7 +27,7 @@ jobs:
 
               [1]: https://mmistakes.github.io/minimal-mistakes/
               [2]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests
-      - uses: sudo-bot/action-pull-request-lock@v1.0.5
+      - uses: sudo-bot/action-pull-request-lock@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           number: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
I am the author of the GH action. And since [v2](https://github.com/sudo-bot/action-pull-request-lock/releases/tag/v2) is out there I wanted to find a random repo that uses my project to make a bump 😄 