### PR TITLE
Allow per-post or per-collection `date_format` values.

### DIFF
--- a/_includes/page__date.html
+++ b/_includes/page__date.html
@@ -1,5 +1,5 @@
 {% assign locale = include.locale | default: site.locale %}
-{% assign date_format = site.date_format | default: "%B %-d, %Y" %}
+{% assign date_format = page.date_format | default: site.date_format | default: "%B %-d, %Y" %}
 {% if page.last_modified_at %}
   <p class="page__date"><strong><i class="fas fa-fw fa-calendar-alt" aria-hidden="true"></i> {{ site.data.ui-text[locale].date_label | default: "Updated:" }}</strong> <time class="dt-updated" datetime="{{ page.last_modified_at | date: "%Y-%m-%d" }}">{{ page.last_modified_at | date: date_format }}</time></p>
 {% elsif page.date %}

--- a/_includes/page__meta.html
+++ b/_includes/page__meta.html
@@ -6,7 +6,7 @@
       {% assign date = document.date %}
       <span class="page__meta-date">
         <i class="far {% if include.type == 'grid' and document.read_time and document.show_date %}fa-fw {% endif %}fa-calendar-alt" aria-hidden="true"></i>
-        {% assign date_format = site.date_format | default: "%B %-d, %Y" %}
+        {% assign date_format = document.date_format | default: site.date_format | default: "%B %-d, %Y" %}
         <time datetime="{{ date | date_to_xmlschema }}">{{ date | date: date_format }}</time>
       </span>
     {% endif %}

--- a/docs/_docs/05-configuration.md
+++ b/docs/_docs/05-configuration.md
@@ -259,11 +259,13 @@ defaults:
 
 To disable post date for a post, add `show_date: false` to its YAML Front Matter, overriding what was set in `_config.yml`.
 
-When dates are shown on blog posts or pages, a date format will be chosen to format the date string. The default format is `"%B %-d, %Y"`, which will be displayed like "February 24, 2016". You can choose your date format by referencing this [cheat sheet](https://www.shortcutfoo.com/app/dojos/ruby-date-format-strftime/cheatsheet). For example, use your date format in `_config.yml`.
+When dates are shown on blog posts or pages, a date format will be chosen to format the date string. The default format is `"%B %-d, %Y"`, which will be displayed like "February 24, 2016". You can choose your date format by referencing this [cheat sheet](https://www.shortcutfoo.com/app/dojos/ruby-date-format-strftime/cheatsheet). For example, to use ISO 8601 style dates, use this date format:
 
 ```yaml
 date_format: "%Y-%m-%d"
 ```
+
+You can set a custom `date_format` for the entire site as a top-level entry in `_config.yml`. You can override the site's `date_format` for a specific post by putting it in the YAML Front Matter, or for groups of posts in the `_config.yml` defaults (just like you can with `show_date`).
 
 ### Reading time
 


### PR DESCRIPTION
This is an enhancement or feature

## Summary

Update `_include/page__date.html` and `_include/page__meta.html` to read custom `date_format` values from the `page` / `document` object.

## Context

I wanted to add a `collection` to my site, and use a different date format for them (Month Year, omitting the day), and discovered it wasn't a built-in feature.

I think this is a reasonable approach, and seems in line with the recent addition of `locale`. My specific use case is using the `defaults` to avoid repeating it in every YAML front matter block:

```yaml
defaults:
  - scope:
      path: ""
      type: portfolio
    values:
      layout: single
      show_date: true
      date_format: "%B %Y"
```