### PR TITLE
Replace inline style padding-left with padding-inline-start for RTL support

### DIFF
--- a/_includes/nav_list
+++ b/_includes/nav_list
@@ -1,6 +1,6 @@
 {% assign locale = include.locale | default: site.locale %}
 <nav class="nav__list">
-  {% if page.sidebar.title %}<h3 class="nav__title" style="padding-left: 0;">{{ page.sidebar.title }}</h3>{% endif %}
+  {% if page.sidebar.title %}<h3 class="nav__title" style="padding-inline-start: 0;">{{ page.sidebar.title }}</h3>{% endif %}
   <input id="ac-toc" name="accordion-toc" type="checkbox" />
   <label for="ac-toc">{{ site.data.ui-text[locale].menu_label | default: "Toggle Menu" }}</label>
   <ul class="nav__items">


### PR DESCRIPTION
This is a bug fix.

## Summary

Replace inline style padding-left with padding-inline-start for RTL support.
