### PR TITLE
Update bad-pr.yml script from ubuntu-slim to ubuntu-latest

### DIFF
--- a/.github/workflows/bad-pr.yml
+++ b/.github/workflows/bad-pr.yml
@@ -11,7 +11,7 @@ jobs:
   close-pr:
     permissions:
       pull-requests: write
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest
     if: "contains(github.event.pull_request.body, 'by deleting this comment block') || github.event.pull_request.body == ''"
     steps:
       - uses: actions-ecosystem/action-add-labels@v1


### PR DESCRIPTION
ubuntu-slim has been updated to not support docker causing script to fail, updating what the job runs on resolves this.

<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - Read the contributing document at https://github.com/mmistakes/minimal-mistakes#contributing
-->

This is a bug fix that resolves a similar issue seen on [Academic Pages](https://github.com/academicpages/academicpages.github.io/tree/master), appeared in a recent PR to minimal-mistakes (see [this PR](https://github.com/mmistakes/minimal-mistakes/actions/runs/25929987622/job/76221135311)), has been reported elsewhere on GitHub (ex., [Docker pull failed on ubuntu-slim](https://github.com/actions/runner-images/issues/13583)), and a recent update to [the runners reference](https://docs.github.com/en/actions/reference/runners/github-hosted-runners#limitations-for-arm64-macos-runners) also notes the limitation due to running in unprivileged mode.