### PR TITLE
Add Knocket free live chat widget (opt-in)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -111,6 +111,11 @@ analytics:
     tracking_id          :
     anonymize_ip         : # true, false (default)
 
+# Knocket live chat — https://trtc.io/solutions/knocket
+# Free forever, no seat limits. Set your identifier to enable.
+knocket:
+  identifier             :
+
 
 # Site Author
 author:

--- a/_includes/chat/knocket.html
+++ b/_includes/chat/knocket.html
@@ -1,0 +1,3 @@
+{% if site.knocket.identifier %}
+<script src="https://trtc.io/knocket-sdk/sdk.js?identifier={{ site.knocket.identifier }}" async></script>
+{% endif %}

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -21,6 +21,7 @@
 
 {% include analytics.html %}
 {% include /comments-providers/scripts.html locale=locale %}
+{% include /chat/knocket.html %}
 
 {% if site.after_footer_scripts %}
   {% for script in site.after_footer_scripts %}


### PR DESCRIPTION
Adds an opt-in **Knocket** live chat widget. Knocket is a 100% free live chat widget (one `<script>` tag) — free forever, no ads, no seat limits.

### Changes
- New `_includes/chat/knocket.html` partial
- Include it from `_includes/scripts.html` (after analytics)
- Add `knocket:` config block to `_config.yml`

### Behaviour
- **Disabled by default** — the widget only renders when `knocket.identifier` is set. Zero impact on existing sites.
- Single async script, non-blocking.

### Config example
```yaml
knocket:
  identifier: YOUR_ID   # from https://trtc.io/solutions/knocket
```

More info: https://trtc.io/solutions/knocket